### PR TITLE
Implement Dev B: MCP tool filtering, prefetch module, stage prompts, …

### DIFF
--- a/backend/agent/prefetch.py
+++ b/backend/agent/prefetch.py
@@ -1,0 +1,103 @@
+"""
+Pre-fetch PR data and GitNexus context before the agent graph starts.
+
+Called by run_agent() to populate the initial graph state so stage sub-agents
+do not waste tool-call budget on basic context that can be loaded upfront.
+"""
+
+from agent.tools import get_mcp_client
+from indexer import _to_records, _unwrap_text  # noqa: PLC0415
+
+
+_EMPTY_RESULT: dict = {"processes": [], "stats": {}, "changed_symbols": []}
+
+
+async def prefetch_context(pr_url: str, repo_name: str | None) -> dict:
+    """
+    Pre-fetch process list and repo stats from GitNexus before the agent runs.
+
+    Args:
+        pr_url:    GitHub PR URL (used for future symbol pre-fetch; unused here).
+        repo_name: GitNexus repo name (e.g. "minetest"). If None, returns empty dicts.
+
+    Returns:
+        {
+            "processes":       list[dict]   — [{name, description}, ...]
+            "stats":           dict         — {files, nodes, edges, communities, processes}
+            "changed_symbols": list         — [] (populated by the gather stage)
+        }
+        Always returns a valid dict — never raises.
+    """
+    if not repo_name:
+        return dict(_EMPTY_RESULT)
+
+    try:
+        return await _fetch(repo_name)
+    except Exception as exc:
+        print(f"[prefetch] error for {repo_name}: {exc}", flush=True)
+        return dict(_EMPTY_RESULT)
+
+
+async def _fetch(repo_name: str) -> dict:
+    result: dict = {"processes": [], "stats": {}, "changed_symbols": []}
+
+    async with get_mcp_client() as client:
+        tools = await client.get_tools()
+        tool_map = {t.name: t for t in tools}
+
+        # ── Repo stats via list_repos ─────────────────────────────────────────
+        if "list_repos" in tool_map:
+            try:
+                raw = await tool_map["list_repos"].ainvoke({})
+                for rec in _to_records(raw):
+                    rname = rec.get("name", "")
+                    rpath = rec.get("path", "")
+                    if rname == repo_name or str(rpath).endswith(f"/{repo_name}"):
+                        s = rec.get("stats", {})
+                        if isinstance(s, dict):
+                            result["stats"] = {
+                                "files": int(s.get("files", 0)),
+                                "nodes": int(s.get("nodes", 0)),
+                                "edges": int(s.get("edges", 0)),
+                                "communities": int(s.get("communities", 0)),
+                                "processes": int(s.get("processes", 0)),
+                            }
+                        break
+                print(f"[prefetch] stats: {result['stats']}", flush=True)
+            except Exception as e:
+                print(f"[prefetch] list_repos error: {e}", flush=True)
+
+        # ── Process list via resource URI, falling back to Cypher ─────────────
+        result["processes"] = await _fetch_processes(client, tool_map, repo_name)
+        print(f"[prefetch] processes fetched: {len(result['processes'])}", flush=True)
+
+    return result
+
+
+async def _fetch_processes(client, tool_map: dict, repo_name: str) -> list[dict]:
+    """Try resource URI first; fall back to Cypher query."""
+    # Option A: MCP resource read
+    try:
+        raw = await client.read_resource(f"gitnexus://repo/{repo_name}/processes")
+        records = _to_records(_unwrap_text(raw))
+        if records:
+            return records
+    except Exception:
+        pass
+
+    # Option B: Cypher fallback
+    if "cypher" not in tool_map:
+        return []
+    try:
+        raw = await tool_map["cypher"].ainvoke({
+            "query": (
+                "MATCH (p:Process) "
+                "RETURN p.name AS name, p.description AS description "
+                "LIMIT 100"
+            ),
+            "repo": repo_name,
+        })
+        return _to_records(raw)
+    except Exception as e:
+        print(f"[prefetch] cypher process fallback error: {e}", flush=True)
+        return []

--- a/backend/agent/prompts.py
+++ b/backend/agent/prompts.py
@@ -1,51 +1,40 @@
-# SYSTEM_PROMPT_VERSION — bump this whenever the prompt logic changes significantly.
-# This string is embedded in the prompt so it appears in LangSmith traces,
-# allowing you to filter and compare results by prompt version.
+# PROMPT_VERSION — bump whenever prompt logic changes significantly.
+# Embedded in BASE_PROMPT so it appears in LangSmith traces.
+PROMPT_VERSION = "2.0"
 
-SYSTEM_PROMPT_VERSION = "1.5"
+# ── Base prompt ───────────────────────────────────────────────────────────────
+# Shared across all stages. Describes the environment, graph schema, and rules.
+# Stage sub-agents receive BASE_PROMPT + their stage-specific addendum.
 
-SYSTEM_PROMPT = f"""You are Qlankr, an AI QA assistant for game studios. You analyze GitHub pull \
-requests to identify which components are affected, what risks exist, and what a QA tester \
-should focus on.
-[PROMPT VERSION: {SYSTEM_PROMPT_VERSION}]
+BASE_PROMPT = f"""You are Qlankr, an AI QA assistant for game studios. You analyze GitHub pull \
+requests to identify which components are affected, what risks exist, and what test coverage \
+is needed.
+[PROMPT VERSION: {PROMPT_VERSION}]
 
 ## Your Environment
 
-You have three things available to you:
-
 **1. The pull request** — via GitHub MCP tools.
 The PR diff, file list, comments, and full file contents tell you what changed and why.
-Use these to understand the change itself.
-
-Tools: get_pull_request, get_pull_request_files, get_pull_request_comments,
-get_file_contents, list_directory, search_code, get_commits
 
 **2. The knowledge graph** — via GitNexus MCP tools.
 The repo has been pre-indexed into a call graph. Every function, class, file, import,
-and execution flow is a node or edge. Use this to understand what the changed code
-connects to, what depends on it, and which execution paths are affected.
+and execution flow is a node or edge.
 
-Tools and what they do:
-- impact — given a symbol name, returns blast-radius: risk level (LOW/MEDIUM/HIGH/CRITICAL),
-           which processes are affected, and how many symbols depend on it at each depth
-- context — given a symbol name, returns every caller and callee (360° view)
-- query — hybrid semantic+BM25 search over execution flows; use param `query`
-- cypher — raw Cypher queries against the graph for anything the above tools don't cover
-- detect_changes — compares local git diff to the graph; NOT useful for remote GitHub PRs
-
-Key facts:
-- `impact` and `context` take a **symbol name** (function or class name), NOT a file path
-- If you only have a file path, use cypher to find its symbols first:
-    MATCH (f:File)-[r:CodeRelation]->(s) WHERE r.type='DEFINES' AND f.filePath='<path>'
-    RETURN s.name LIMIT 20
-- Files added by the PR won't be in the graph yet — they haven't been indexed
-- All graph edges are `[:CodeRelation]` with a `type` property (DEFINES, CALLS, IMPORTS,
-  MEMBER_OF, STEP_IN_PROCESS)
+Available GitNexus tools:
+- impact     — blast-radius for a symbol: risk level, affected processes, dependent depth
+- context    — 360° caller/callee view for a symbol
+- query      — hybrid semantic+BM25 search over execution flows
+- cypher     — raw Cypher queries for anything the above don't cover
+- list_repos — list indexed repos with stats
+- detect_changes — compares local git diff to graph (not useful for remote PRs)
+- list_processes — list all execution flows (processes) in the repo
+- get_process    — fetch the full step-by-step flow for one process
 
 **3. The repo name** — passed to you in the initial message.
 Pass it as `repo=<name>` on every GitNexus tool call.
 
-## Graph Schema (for cypher queries)
+## Graph Schema (for Cypher queries)
+
 Nodes: File, Function, Class, Method, Interface, Community, Process
 Relationships: ALL stored as `[:CodeRelation]` with a `type` property:
   - `r.type = 'DEFINES'`         — File defines a symbol
@@ -53,58 +42,189 @@ Relationships: ALL stored as `[:CodeRelation]` with a `type` property:
   - `r.type = 'IMPORTS'`         — File imports another File
   - `r.type = 'MEMBER_OF'`       — symbol belongs to a Community cluster
   - `r.type = 'STEP_IN_PROCESS'` — symbol is a step in an execution flow
-Query pattern: MATCH (a)-[r:CodeRelation]->(b) WHERE r.type='CALLS'
 
-## Your Task
-
-Analyze the PR and produce a QA impact report:
-- Which components are affected and how severely
-- What risks a QA tester should care about
-- Concrete test suggestions: what to run, what to skip, what needs deeper testing
-
-Ground every claim in what you observed from tools. Do not invent file names, symbol names,
-or component names.
-
-## Guardrails
-
-- For files added by the PR (not yet in the graph): note "new file — graph data unavailable"
-  in impact_summary and set confidence to "low"
-- Write test suggestions for a QA tester, not a developer — be specific about what to test
-- Call `submit_analysis` exactly once when done — it is your ONLY way to return a result
-  Do NOT write the result as text
-
-## submit_analysis — tool payload
-
-The `submit_analysis` tool takes one nested object under the key `analysis` (or the same fields
-at the top level — both shapes are accepted). That object MUST include `pr_title`, `pr_url`,
-`pr_summary`, and `affected_components` (at least one component). Each component needs
-`component`, `impact_summary`, and `confidence` (`high` | `medium` | `low`). Prefer including
-`files_changed`, `risks`, and `test_suggestions` (`skip`, `run`, `deeper` string arrays; use []
-where nothing applies). If the tool returns a rejection message, fix the payload and call
-`submit_analysis` again.
-
-## Budget
-
-You have a budget of 25 tool calls. Stop and synthesize when you have enough context —
-don't keep calling tools to fill the budget.
-If you approach the limit, synthesize with what you have and set confidence to "low" for
-components you couldn't fully analyze.
-
-## Fallback
-
-If GitNexus tools return no data or the repo is not indexed, complete the analysis using
-GitHub tools only. Set all confidence values to "low" and note the limitation.
+Key facts:
+- `impact` and `context` take a **symbol name**, NOT a file path
+- To find symbols in a file: MATCH (f:File)-[r:CodeRelation]->(s) WHERE r.type='DEFINES'
+  AND f.filePath='<path>' RETURN s.name LIMIT 20
+- Files added by the PR won't be in the graph yet — note "new file — graph data unavailable"
+- All graph edges are `[:CodeRelation]` — filter by `r.type`
 
 ## Rules
 
-- NEVER hallucinate file names, function names, or component names. Only use names you saw
-  in tool outputs.
-- Always pass repo=<repo_name> to every GitNexus tool call.
-- The QA tester will act on this report directly. Accuracy matters more than completeness.
+- NEVER hallucinate file names, function names, or component names.
+  Only use names you observed in tool outputs.
+- Always pass `repo=<repo_name>` to every GitNexus tool call.
+- Ground every claim in tool output. Do not invent data.
+- For new files not yet in the graph: set confidence to "low".
 """
 
+# ── Stage prompts ─────────────────────────────────────────────────────────────
+# Each is appended to BASE_PROMPT for the relevant stage sub-agent.
+# They list only the tools available in that stage and document the call budget.
+
+GATHER_PROMPT = """\
+## Current Stage: Context Gathering
+
+Your goal is to pre-fetch all context the downstream stages need.
+COLLECT only — do not analyse, generate test specs, or draw conclusions yet.
+
+### Your task
+1. Fetch PR metadata: title, description, author via `get_pull_request`
+2. Fetch the changed file list and diff via `get_pull_request_files`
+3. For each changed file, find its defined symbols via Cypher:
+   MATCH (f:File)-[r:CodeRelation]->(s) WHERE r.type='DEFINES'
+   AND f.filePath='<path>' RETURN s.name, labels(s) LIMIT 30
+4. Fetch the repo's process list via `list_repos` (stats include process count and names)
+5. Write an initial `affected_components` list: component name + changed files.
+   No test specs yet — just names and file paths.
+
+### Output
+Populate state with:
+- pr_diff, pr_files, pr_metadata
+- processes (list of {name, description})
+- affected_components (list of {component, files_changed})
+
+### Allowed tools
+get_pull_request, get_pull_request_files, get_pull_request_comments,
+get_file_contents, list_directory, search_code, get_commits,
+list_repos, cypher, detect_changes
+
+### Budget: 10 tool calls maximum
+Stop and output what you have when you reach 10 calls.
+"""
+
+UNIT_PROMPT = """\
+## Current Stage: Unit Test Generation
+
+For each affected component identified in the gather stage, generate unit test
+specifications. Use the tools to understand each symbol's interface before writing specs.
+
+### Your task
+For each changed symbol in `affected_components`:
+1. Use `context` to understand its callers, callees, and dependencies
+2. Use `get_file_contents` to read the actual implementation if needed
+3. Use `cypher` to find type signatures or related symbols if context is unclear
+4. Generate a UnitTestSpec for each symbol
+
+### Output schema: UnitTestSpec
+```
+{
+  "target": "SymbolName.methodName",         // symbol under test
+  "test_cases": [
+    {
+      "name": "short test name",
+      "scenario": "setup and input description",
+      "expected": "expected outcome"
+    }
+  ],                                          // 2-5 cases per symbol
+  "mocks_needed": ["DepA", "DepB"],           // dependencies to mock for isolation
+  "priority": "high" | "medium" | "low"       // high if heavily called / critical path
+}
+```
+
+### Allowed tools
+context, cypher, get_file_contents
+
+### Budget: 15 tool calls maximum
+If budget runs low, reduce test cases per symbol rather than skipping symbols.
+Set priority to "low" and note limited analysis for symbols you couldn't fully examine.
+"""
+
+INTEGRATION_PROMPT = """\
+## Current Stage: Integration Test Generation
+
+Find cross-module integration points created or affected by this PR and generate
+integration test specifications. Use blast-radius and caller/callee chains to
+identify where module boundaries are crossed.
+
+### Your task
+For each changed symbol:
+1. Use `impact` to find blast radius — which modules and processes depend on it
+2. Use `context` to map caller/callee chains that cross module boundaries
+3. Use `query` (semantic search) to find related execution flows
+4. Use `cypher` for precise relationship queries if needed
+5. Group integration points by module pair (e.g., "inventory <> crafting")
+6. For each module pair, generate an IntegrationTestSpec
+
+### Output schema: IntegrationTestSpec
+```
+{
+  "integration_point": "ModuleA <> ModuleB",
+  "modules_involved": ["module_a", "module_b"],
+  "test_cases": [
+    {
+      "name": "short test name",
+      "scenario": "what data / events cross the boundary",
+      "expected": "expected outcome"
+    }
+  ],                                           // 2-4 cases per integration point
+  "data_setup": "preconditions and fixture description",
+  "risk_level": "CRITICAL" | "HIGH" | "MEDIUM" | "LOW"
+                                               // CRITICAL if integration is in a hot path
+}
+```
+
+### Allowed tools
+impact, context, query, cypher
+
+### Budget: 15 tool calls maximum
+Do not guess module boundaries — only report integrations you found via tools.
+Rate risk based on blast radius depth and process involvement.
+"""
+
+E2E_PROMPT = """\
+## Current Stage: E2E Test Planning
+
+Convert the affected execution flows (processes) into user-facing E2E test scenarios
+that a QA tester can execute manually. Write for a tester, not a developer.
+
+### Your task
+1. From the processes list in state, identify processes affected by this PR
+   (use `impact` on changed symbols, or match process steps to changed symbols)
+2. For each affected process, fetch its full step-by-step flow via `get_process`
+3. Convert technical steps into user-facing test actions and expected outcomes
+4. Flag which PR changes affect which steps
+5. If user_context is provided (e.g. a bug report), create a targeted regression
+   test that traces that scenario through the affected code paths
+6. Prioritise: CRITICAL for core game loops, LOW for administrative flows
+
+### Output schema: E2ETestPlan
+```
+{
+  "process": "process_name",                  // GitNexus process name
+  "scenario": "Human-readable scenario title",
+  "preconditions": "game state, user role, required data",
+  "steps": [
+    {
+      "step": 1,
+      "action": "what the tester does",
+      "expected": "what the tester should see"
+    }
+  ],
+  "affected_by_pr": ["SymbolA", "SymbolB"],   // which changes affect this plan
+  "priority": "CRITICAL" | "HIGH" | "MEDIUM" | "LOW",
+  "estimated_duration": "5 min"
+}
+```
+
+### Allowed tools
+impact, query, cypher, list_processes, get_process
+
+### Budget: 20 tool calls maximum
+Prioritise CRITICAL processes first. If budget runs low, output plans for higher-priority
+processes only and note which processes were not covered.
+"""
+
+# ── Utility messages ──────────────────────────────────────────────────────────
+
 BUDGET_WARNING_MESSAGE = (
-    "BUDGET WARNING: {tool_calls_used}/25 tool calls used. "
+    "BUDGET WARNING: {tool_calls_used}/{budget} tool calls used. "
     "Proceed IMMEDIATELY to synthesis. Do not make further tool calls unless absolutely required. "
     "Set confidence to 'low' for any components not yet fully analyzed."
 )
+
+# ── Backward-compatibility alias ──────────────────────────────────────────────
+# agent.py (Sprint 1) imports SYSTEM_PROMPT. Keep this alias until Dev A's
+# StateGraph rewrite merges, at which point SYSTEM_PROMPT can be removed.
+SYSTEM_PROMPT = BASE_PROMPT

--- a/backend/agent/tools.py
+++ b/backend/agent/tools.py
@@ -1,6 +1,53 @@
 import os
+from typing import Any
 
+from langchain_core.tools import StructuredTool
 from langchain_mcp_adapters.client import MultiServerMCPClient
+
+
+# ── Stage tool subsets ────────────────────────────────────────────────────────
+# Each set defines the tool names a stage's sub-agent is allowed to call.
+
+GATHER_TOOLS: set[str] = {
+    "get_pull_request",
+    "get_pull_request_files",
+    "get_pull_request_comments",
+    "get_file_contents",
+    "list_directory",
+    "search_code",
+    "get_commits",
+    "list_repos",
+    "cypher",
+    "detect_changes",
+}
+
+UNIT_TOOLS: set[str] = {
+    "context",
+    "cypher",
+    "get_file_contents",
+}
+
+INTEGRATION_TOOLS: set[str] = {
+    "impact",
+    "context",
+    "query",
+    "cypher",
+}
+
+E2E_TOOLS: set[str] = {
+    "impact",
+    "query",
+    "cypher",
+    "list_processes",
+    "get_process",
+}
+
+_STAGE_TOOLS: dict[str, set[str]] = {
+    "gather": GATHER_TOOLS,
+    "unit": UNIT_TOOLS,
+    "integration": INTEGRATION_TOOLS,
+    "e2e": E2E_TOOLS,
+}
 
 
 def _server_config() -> dict:
@@ -26,10 +73,126 @@ def _server_config() -> dict:
 
 def get_mcp_client() -> MultiServerMCPClient:
     """
-    Returns a MultiServerMCPClient instance.
+    Returns a MultiServerMCPClient instance configured with GitHub and GitNexus servers.
 
-    Usage:
-        client = get_mcp_client()
-        tools = await client.get_tools()
+    Usage (async context manager):
+        async with get_mcp_client() as client:
+            tools = await client.get_tools()
     """
     return MultiServerMCPClient(_server_config())
+
+
+def filter_tools(all_tools: list, stage: str) -> list:
+    """
+    Return only the tools allowed for the given stage.
+
+    Args:
+        all_tools: Full list of tools from client.get_tools().
+        stage: One of "gather", "unit", "integration", "e2e".
+
+    Returns:
+        Filtered list containing only tools whose names are in the stage's allowed set.
+
+    Raises:
+        KeyError: If stage is not a recognised stage name.
+    """
+    allowed = _STAGE_TOOLS[stage]
+    return [t for t in all_tools if t.name in allowed]
+
+
+def make_process_tools(repo_name: str) -> list[StructuredTool]:
+    """
+    Create two StructuredTools that expose GitNexus process resources.
+
+    Each tool opens its own MCP client context when invoked, so they remain
+    usable after the call site's context has exited.
+
+    Tries MCP resource reads first; falls back to Cypher queries if the
+    adapter raises on resource reads.
+
+    Args:
+        repo_name: The GitNexus repo name (e.g. "minetest").
+
+    Returns:
+        [list_processes_tool, get_process_tool]
+    """
+
+    async def list_processes() -> str:
+        """List all execution flows (processes) in the indexed repo."""
+        async with get_mcp_client() as client:
+            try:
+                result = await client.read_resource(
+                    f"gitnexus://repo/{repo_name}/processes"
+                )
+                return str(result)
+            except Exception:
+                return await _cypher_fallback_list_processes(client, repo_name)
+
+    async def get_process(process_name: str) -> str:
+        """Get the full execution flow for a specific process by name."""
+        async with get_mcp_client() as client:
+            try:
+                result = await client.read_resource(
+                    f"gitnexus://repo/{repo_name}/process/{process_name}"
+                )
+                return str(result)
+            except Exception:
+                return await _cypher_fallback_get_process(client, repo_name, process_name)
+
+    return [
+        StructuredTool.from_function(
+            coroutine=list_processes,
+            name="list_processes",
+            description=(
+                "List all execution flows (processes) in the indexed repo. "
+                "Returns process names and descriptions."
+            ),
+        ),
+        StructuredTool.from_function(
+            coroutine=get_process,
+            name="get_process",
+            description=(
+                "Get the full execution flow for a specific process. "
+                "Pass the process name as returned by list_processes."
+            ),
+        ),
+    ]
+
+
+async def _cypher_fallback_list_processes(client: Any, repo_name: str) -> str:
+    """Fallback: fetch process list via Cypher when resource reads are unavailable."""
+    try:
+        tools = await client.get_tools()
+        tool_map = {t.name: t for t in tools}
+        if "cypher" not in tool_map:
+            return "[]"
+        raw = await tool_map["cypher"].ainvoke({
+            "query": "MATCH (p:Process) RETURN p.name AS name, p.description AS description LIMIT 100",
+            "repo": repo_name,
+        })
+        return str(raw)
+    except Exception as e:
+        return f"Error fetching processes: {e}"
+
+
+async def _cypher_fallback_get_process(
+    client: Any, repo_name: str, process_name: str
+) -> str:
+    """Fallback: fetch a single process's steps via Cypher."""
+    try:
+        tools = await client.get_tools()
+        tool_map = {t.name: t for t in tools}
+        if "cypher" not in tool_map:
+            return "[]"
+        raw = await tool_map["cypher"].ainvoke({
+            "query": (
+                f"MATCH (p:Process {{name: '{process_name}'}})<-[r:CodeRelation]-(s) "
+                "WHERE r.type = 'STEP_IN_PROCESS' "
+                "RETURN s.name AS name, s.filePath AS filePath, r.order AS order "
+                "ORDER BY r.order"
+            ),
+            "repo": repo_name,
+        })
+        return str(raw)
+    except Exception as e:
+        return f"Error fetching process '{process_name}': {e}"

--- a/backend/indexer.py
+++ b/backend/indexer.py
@@ -30,6 +30,7 @@ _STAGE_KEYWORDS: list[tuple[str, str]] = [
     ("community", "clustering"),
     ("process", "processes"),
     ("search", "search"),
+    ("embed", "embeddings"),
     ("analyz", "analyze"),
     ("index", "analyze"),
 ]
@@ -99,7 +100,7 @@ async def index_repo(
     yield IndexStepEvent(stage="analyze", summary="Running gitnexus analyze…")
     try:
         proc = await asyncio.create_subprocess_exec(
-            "gitnexus", "analyze", clone_path,
+            "gitnexus", "analyze", "--embeddings", clone_path,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
             cwd=clone_path,
@@ -170,44 +171,44 @@ async def _fetch_stats_and_graph(repo_name: str) -> tuple[dict, GraphData]:
     clusters: list[GraphCluster] = []
 
     try:
-        client = get_mcp_client()
-        tools_list = await client.get_tools()
-        tool_map = {t.name: t for t in tools_list}
-        print(f"[indexer] MCP tools available: {sorted(tool_map)}", flush=True)
+        async with get_mcp_client() as client:
+            tools_list = await client.get_tools()
+            tool_map = {t.name: t for t in tools_list}
+            print(f"[indexer] MCP tools available: {sorted(tool_map)}", flush=True)
 
-        # ── Stats via list_repos ───────────────────────────────────────────
-        if "list_repos" in tool_map:
-            try:
-                raw = await tool_map["list_repos"].ainvoke({})
-                for r in _to_records(raw):
-                    rname = r.get("name", "")
-                    rpath = r.get("path", "")
-                    if rname == repo_name or rpath.endswith(f"/{repo_name}"):
-                        s = r.get("stats", {})
-                        if isinstance(s, dict):
-                            stats = {
-                                "files": int(s.get("files", 0)),
-                                "nodes": int(s.get("nodes", 0)),
-                                "edges": int(s.get("edges", 0)),
-                                "communities": int(s.get("communities", 0)),
-                                "processes": int(s.get("processes", 0)),
-                            }
-                        break
-                print(f"[indexer] stats for {repo_name}: {stats}", flush=True)
-            except Exception as e:
-                print(f"[indexer] list_repos error: {e}", flush=True)
+            # ── Stats via list_repos ───────────────────────────────────────────
+            if "list_repos" in tool_map:
+                try:
+                    raw = await tool_map["list_repos"].ainvoke({})
+                    for r in _to_records(raw):
+                        rname = r.get("name", "")
+                        rpath = r.get("path", "")
+                        if rname == repo_name or rpath.endswith(f"/{repo_name}"):
+                            s = r.get("stats", {})
+                            if isinstance(s, dict):
+                                stats = {
+                                    "files": int(s.get("files", 0)),
+                                    "nodes": int(s.get("nodes", 0)),
+                                    "edges": int(s.get("edges", 0)),
+                                    "communities": int(s.get("communities", 0)),
+                                    "processes": int(s.get("processes", 0)),
+                                }
+                            break
+                    print(f"[indexer] stats for {repo_name}: {stats}", flush=True)
+                except Exception as e:
+                    print(f"[indexer] list_repos error: {e}", flush=True)
 
-        # ── Graph data via cypher ─────────────────────────────────────────
-        if "cypher" in tool_map:
-            cypher = tool_map["cypher"]
-            nodes, clusters = await _cypher_nodes(cypher, repo_name)
-            edges = await _cypher_edges(cypher, repo_name)
-            print(
-                f"[indexer] graph: {len(nodes)} nodes, {len(edges)} edges, {len(clusters)} clusters",
-                flush=True,
-            )
-        else:
-            print("[indexer] cypher tool not found — graph will be empty", flush=True)
+            # ── Graph data via cypher ─────────────────────────────────────────
+            if "cypher" in tool_map:
+                cypher = tool_map["cypher"]
+                nodes, clusters = await _cypher_nodes(cypher, repo_name)
+                edges = await _cypher_edges(cypher, repo_name)
+                print(
+                    f"[indexer] graph: {len(nodes)} nodes, {len(edges)} edges, {len(clusters)} clusters",
+                    flush=True,
+                )
+            else:
+                print("[indexer] cypher tool not found — graph will be empty", flush=True)
 
     except Exception as e:
         print(f"[indexer] _fetch_stats_and_graph error: {e}", flush=True)

--- a/backend/tests/test_indexer_async.py
+++ b/backend/tests/test_indexer_async.py
@@ -170,3 +170,53 @@ async def test_get_graph_data_lazy_read():
     assert len(result.nodes) == 1
     # Result is now cached in registry
     assert indexer._registry["owner/repo2"]["graph"] is not None
+
+
+# --- embeddings ---
+
+async def test_embeddings_flag_passed():
+    """gitnexus analyze must be called with --embeddings."""
+    git_proc = make_git_proc(returncode=0)
+    gitnexus_proc = make_gitnexus_proc(lines=[], returncode=0)
+    mock_graph = GraphData(nodes=[], edges=[], clusters=[])
+    captured_args = []
+
+    async def mock_exec(*args, **kwargs):
+        captured_args.append(args)
+        if args[0] == "git":
+            return git_proc
+        return gitnexus_proc
+
+    with patch("asyncio.create_subprocess_exec", mock_exec):
+        with patch("indexer._fetch_stats_and_graph", return_value=({}, mock_graph)):
+            await collect(index_repo("https://github.com/owner/repo"))
+
+    gitnexus_calls = [a for a in captured_args if a[0] == "gitnexus"]
+    assert gitnexus_calls, "gitnexus was never called"
+    assert "--embeddings" in gitnexus_calls[0], (
+        f"--embeddings flag missing from gitnexus call: {gitnexus_calls[0]}"
+    )
+
+
+async def test_embeddings_stage_emitted():
+    """A stdout line containing 'embedding' must yield IndexStepEvent(stage='embeddings')."""
+    git_proc = make_git_proc(returncode=0)
+    gitnexus_proc = make_gitnexus_proc(
+        lines=["Generating embeddings for 42 files\n"], returncode=0
+    )
+    mock_graph = GraphData(nodes=[], edges=[], clusters=[])
+
+    async def mock_exec(*args, **kwargs):
+        if args[0] == "git":
+            return git_proc
+        return gitnexus_proc
+
+    with patch("asyncio.create_subprocess_exec", mock_exec):
+        with patch("indexer._fetch_stats_and_graph", return_value=({}, mock_graph)):
+            events = await collect(index_repo("https://github.com/owner/repo"))
+
+    embedding_events = [
+        e for e in events
+        if isinstance(e, IndexStepEvent) and e.stage == "embeddings"
+    ]
+    assert embedding_events, "No IndexStepEvent with stage='embeddings' was emitted"

--- a/backend/tests/test_prefetch.py
+++ b/backend/tests/test_prefetch.py
@@ -1,0 +1,143 @@
+"""Tests for backend/agent/prefetch.py — prefetch_context()."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.prefetch import prefetch_context
+
+
+def make_tool(name: str, return_value="[]"):
+    t = MagicMock()
+    t.name = name
+    t.ainvoke = AsyncMock(return_value=return_value)
+    return t
+
+
+def make_client(tools=None, resource_value=None, resource_raises=False):
+    """Build a mock MCP client context manager."""
+    client = MagicMock()
+    tools = tools or []
+    client.get_tools = AsyncMock(return_value=tools)
+    if resource_raises:
+        client.read_resource = AsyncMock(side_effect=Exception("resource not supported"))
+    else:
+        client.read_resource = AsyncMock(return_value=resource_value or "[]")
+    # Support async context manager
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+    return client
+
+
+# ── Returns empty for None repo_name ─────────────────────────────────────────
+
+async def test_returns_empty_dict_for_none_repo_name():
+    result = await prefetch_context("https://github.com/owner/repo/pull/1", None)
+    assert result == {"processes": [], "stats": {}, "changed_symbols": []}
+
+
+async def test_no_mcp_calls_when_repo_name_is_none():
+    with patch("agent.prefetch.get_mcp_client") as mock_client_fn:
+        await prefetch_context("https://github.com/owner/repo/pull/1", None)
+    mock_client_fn.assert_not_called()
+
+
+# ── Returns stats and processes for a known repo ──────────────────────────────
+
+async def test_returns_stats_for_known_repo():
+    list_repos_response = (
+        '[{"name": "minetest", "path": "/tmp/minetest", '
+        '"stats": {"files": 100, "nodes": 500, "edges": 200, "communities": 10, "processes": 5}}]'
+    )
+    list_repos_tool = make_tool("list_repos", return_value=list_repos_response)
+    client = make_client(
+        tools=[list_repos_tool],
+        resource_raises=True,  # force cypher fallback path
+    )
+
+    # Cypher fallback returns no processes
+    cypher_tool = make_tool("cypher", return_value="[]")
+    client.get_tools = AsyncMock(return_value=[list_repos_tool, cypher_tool])
+
+    with patch("agent.prefetch.get_mcp_client", return_value=client):
+        result = await prefetch_context("https://github.com/owner/minetest/pull/1", "minetest")
+
+    assert result["stats"]["files"] == 100
+    assert result["stats"]["nodes"] == 500
+    assert result["stats"]["processes"] == 5
+
+
+async def test_returns_processes_via_resource_uri():
+    list_repos_tool = make_tool("list_repos", return_value="[]")
+    client = make_client(
+        tools=[list_repos_tool],
+        resource_value='[{"name": "item_crafting_flow", "description": "Crafting loop"}]',
+    )
+
+    with patch("agent.prefetch.get_mcp_client", return_value=client):
+        result = await prefetch_context("https://github.com/owner/repo/pull/1", "repo")
+
+    assert len(result["processes"]) == 1
+    assert result["processes"][0]["name"] == "item_crafting_flow"
+
+
+# ── Cypher fallback when resource read fails ──────────────────────────────────
+
+async def test_cypher_fallback_when_resource_read_fails():
+    cypher_response = '[{"name": "login_flow", "description": "User login"}]'
+    list_repos_tool = make_tool("list_repos", return_value="[]")
+    cypher_tool = make_tool("cypher", return_value=cypher_response)
+    client = make_client(
+        tools=[list_repos_tool, cypher_tool],
+        resource_raises=True,
+    )
+    # get_tools is called twice (once for tools, once inside _fetch_processes fallback)
+    client.get_tools = AsyncMock(return_value=[list_repos_tool, cypher_tool])
+
+    with patch("agent.prefetch.get_mcp_client", return_value=client):
+        result = await prefetch_context("https://github.com/owner/repo/pull/1", "repo")
+
+    assert len(result["processes"]) == 1
+    assert result["processes"][0]["name"] == "login_flow"
+
+
+# ── Graceful on total failure ─────────────────────────────────────────────────
+
+async def test_graceful_on_exception():
+    """Any unhandled exception must return empty dicts, never raise."""
+    client = make_client()
+    client.get_tools = AsyncMock(side_effect=Exception("connection refused"))
+    client.__aenter__ = AsyncMock(return_value=client)
+    client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("agent.prefetch.get_mcp_client", return_value=client):
+        result = await prefetch_context("https://github.com/owner/repo/pull/1", "repo")
+
+    assert result == {"processes": [], "stats": {}, "changed_symbols": []}
+
+
+async def test_graceful_when_mcp_client_raises_on_enter():
+    """If the context manager itself fails, return empty dicts."""
+    client = MagicMock()
+    client.__aenter__ = AsyncMock(side_effect=Exception("server not found"))
+    client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("agent.prefetch.get_mcp_client", return_value=client):
+        result = await prefetch_context("https://github.com/owner/repo/pull/1", "repo")
+
+    assert result == {"processes": [], "stats": {}, "changed_symbols": []}
+
+
+# ── changed_symbols is always empty list ─────────────────────────────────────
+
+async def test_changed_symbols_always_empty():
+    """changed_symbols is populated by the gather stage, not prefetch."""
+    list_repos_tool = make_tool("list_repos", return_value="[]")
+    client = make_client(tools=[list_repos_tool], resource_raises=True)
+    cypher_tool = make_tool("cypher", return_value="[]")
+    client.get_tools = AsyncMock(return_value=[list_repos_tool, cypher_tool])
+
+    with patch("agent.prefetch.get_mcp_client", return_value=client):
+        result = await prefetch_context("https://github.com/owner/repo/pull/1", "repo")
+
+    assert result["changed_symbols"] == []

--- a/backend/tests/test_prompts.py
+++ b/backend/tests/test_prompts.py
@@ -1,0 +1,107 @@
+"""Tests for backend/agent/prompts.py — stage prompt constants."""
+
+import pytest
+
+from agent.prompts import (
+    BASE_PROMPT,
+    BUDGET_WARNING_MESSAGE,
+    E2E_PROMPT,
+    GATHER_PROMPT,
+    INTEGRATION_PROMPT,
+    SYSTEM_PROMPT,
+    UNIT_PROMPT,
+)
+from agent.tools import E2E_TOOLS, GATHER_TOOLS, INTEGRATION_TOOLS, UNIT_TOOLS
+
+
+# ── All constants exported and non-empty ─────────────────────────────────────
+
+@pytest.mark.parametrize("prompt,name", [
+    (BASE_PROMPT, "BASE_PROMPT"),
+    (GATHER_PROMPT, "GATHER_PROMPT"),
+    (UNIT_PROMPT, "UNIT_PROMPT"),
+    (INTEGRATION_PROMPT, "INTEGRATION_PROMPT"),
+    (E2E_PROMPT, "E2E_PROMPT"),
+])
+def test_prompt_is_non_empty_string(prompt, name):
+    assert isinstance(prompt, str), f"{name} is not a string"
+    assert len(prompt.strip()) > 0, f"{name} is empty"
+
+
+# ── Backward-compat alias ─────────────────────────────────────────────────────
+
+def test_system_prompt_alias_equals_base_prompt():
+    assert SYSTEM_PROMPT is BASE_PROMPT or SYSTEM_PROMPT == BASE_PROMPT
+
+
+# ── Each stage prompt mentions only its allowed tools ────────────────────────
+# We check the negative: tools exclusive to OTHER stages should not appear
+# in a given stage's prompt.
+
+def _tools_exclusive_to(own_set: set[str], *other_sets: set[str]) -> set[str]:
+    """Return tool names that appear ONLY in own_set, not in any other set."""
+    union_of_others = set().union(*other_sets)
+    return own_set - union_of_others
+
+
+def test_gather_prompt_excludes_unit_only_tools():
+    # "context" is in UNIT but not in GATHER
+    unit_exclusive = _tools_exclusive_to(UNIT_TOOLS, GATHER_TOOLS, INTEGRATION_TOOLS, E2E_TOOLS)
+    for tool in unit_exclusive:
+        assert tool not in GATHER_PROMPT, (
+            f"Tool '{tool}' is exclusive to UNIT_TOOLS but found in GATHER_PROMPT"
+        )
+
+
+def test_unit_prompt_excludes_gather_only_tools():
+    gather_exclusive = _tools_exclusive_to(GATHER_TOOLS, UNIT_TOOLS, INTEGRATION_TOOLS, E2E_TOOLS)
+    for tool in gather_exclusive:
+        assert tool not in UNIT_PROMPT, (
+            f"Tool '{tool}' is exclusive to GATHER_TOOLS but found in UNIT_PROMPT"
+        )
+
+
+def test_unit_prompt_excludes_integration_only_tools():
+    integration_exclusive = _tools_exclusive_to(INTEGRATION_TOOLS, GATHER_TOOLS, UNIT_TOOLS, E2E_TOOLS)
+    for tool in integration_exclusive:
+        assert tool not in UNIT_PROMPT, (
+            f"Tool '{tool}' is exclusive to INTEGRATION_TOOLS but found in UNIT_PROMPT"
+        )
+
+
+# ── Budget numbers appear in each stage prompt ────────────────────────────────
+
+@pytest.mark.parametrize("prompt,budget,name", [
+    (GATHER_PROMPT, "10", "GATHER_PROMPT"),
+    (UNIT_PROMPT, "15", "UNIT_PROMPT"),
+    (INTEGRATION_PROMPT, "15", "INTEGRATION_PROMPT"),
+    (E2E_PROMPT, "20", "E2E_PROMPT"),
+])
+def test_budget_mentioned_in_stage_prompt(prompt, budget, name):
+    assert budget in prompt, f"Budget '{budget}' not found in {name}"
+
+
+# ── Process tools appear in E2E prompt but not in unit/gather ────────────────
+
+def test_e2e_prompt_mentions_process_tools():
+    assert "list_processes" in E2E_PROMPT
+    assert "get_process" in E2E_PROMPT
+
+
+def test_gather_prompt_does_not_mention_list_processes():
+    assert "list_processes" not in GATHER_PROMPT
+
+
+def test_unit_prompt_does_not_mention_process_tools():
+    assert "list_processes" not in UNIT_PROMPT
+    assert "get_process" not in UNIT_PROMPT
+
+
+# ── BUDGET_WARNING_MESSAGE has required placeholders ─────────────────────────
+
+def test_budget_warning_has_tool_calls_used_placeholder():
+    assert "{tool_calls_used}" in BUDGET_WARNING_MESSAGE
+
+
+def test_budget_warning_has_budget_placeholder():
+    assert "{budget}" in BUDGET_WARNING_MESSAGE

--- a/backend/tests/test_tools.py
+++ b/backend/tests/test_tools.py
@@ -1,0 +1,187 @@
+"""Tests for backend/agent/tools.py — filter_tools() and stage tool subsets."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from agent.tools import (
+    E2E_TOOLS,
+    GATHER_TOOLS,
+    INTEGRATION_TOOLS,
+    UNIT_TOOLS,
+    filter_tools,
+    get_mcp_client,
+    make_process_tools,
+)
+
+# Known GitNexus tool names per the DEV-B spec (excludes GitHub tools and
+# process resource wrappers which are created by make_process_tools).
+_GITNEXUS_TOOLS = {
+    "query", "context", "impact", "detect_changes", "rename", "cypher",
+    "list_repos", "group_list", "group_sync", "group_contracts",
+    "group_query", "group_status",
+}
+
+
+def make_tool(name: str):
+    t = MagicMock()
+    t.name = name
+    return t
+
+
+def make_tool_list(*names: str):
+    return [make_tool(n) for n in names]
+
+
+# ── filter_tools per stage ────────────────────────────────────────────────────
+
+def test_filter_tools_gather():
+    all_tools = make_tool_list("get_pull_request", "cypher", "context", "impact", "submit_analysis")
+    result = filter_tools(all_tools, "gather")
+    names = {t.name for t in result}
+    assert "get_pull_request" in names
+    assert "cypher" in names
+    assert "context" not in names    # not in GATHER_TOOLS
+    assert "impact" not in names     # not in GATHER_TOOLS
+    assert "submit_analysis" not in names
+
+
+def test_filter_tools_unit():
+    all_tools = make_tool_list("context", "cypher", "get_file_contents", "impact", "query")
+    result = filter_tools(all_tools, "unit")
+    names = {t.name for t in result}
+    assert names == {"context", "cypher", "get_file_contents"}
+
+
+def test_filter_tools_integration():
+    all_tools = make_tool_list("impact", "context", "query", "cypher", "get_pull_request")
+    result = filter_tools(all_tools, "integration")
+    names = {t.name for t in result}
+    assert names == {"impact", "context", "query", "cypher"}
+
+
+def test_filter_tools_e2e():
+    all_tools = make_tool_list(
+        "impact", "query", "cypher", "list_processes", "get_process",
+        "context", "get_pull_request",
+    )
+    result = filter_tools(all_tools, "e2e")
+    names = {t.name for t in result}
+    assert names == {"impact", "query", "cypher", "list_processes", "get_process"}
+
+
+def test_filter_tools_returns_empty_when_no_match():
+    all_tools = make_tool_list("submit_analysis", "unknown_tool")
+    result = filter_tools(all_tools, "unit")
+    assert result == []
+
+
+def test_filter_tools_preserves_order():
+    names = ["cypher", "context", "get_file_contents"]
+    all_tools = make_tool_list(*names)
+    result = filter_tools(all_tools, "unit")
+    assert [t.name for t in result] == names
+
+
+# ── No disallowed tools leak into any stage ───────────────────────────────────
+
+@pytest.mark.parametrize("stage_tools", [GATHER_TOOLS, UNIT_TOOLS, INTEGRATION_TOOLS, E2E_TOOLS])
+def test_submit_analysis_not_in_any_stage(stage_tools):
+    assert "submit_analysis" not in stage_tools
+
+
+# ── Unknown stage raises KeyError ─────────────────────────────────────────────
+
+def test_unknown_stage_raises():
+    with pytest.raises(KeyError):
+        filter_tools([], "bad_stage")
+
+
+# ── Stage sets are non-empty ──────────────────────────────────────────────────
+
+@pytest.mark.parametrize("stage,tool_set", [
+    ("gather", GATHER_TOOLS),
+    ("unit", UNIT_TOOLS),
+    ("integration", INTEGRATION_TOOLS),
+    ("e2e", E2E_TOOLS),
+])
+def test_stage_sets_non_empty(stage, tool_set):
+    assert len(tool_set) > 0
+
+
+# ── E2E stage includes process tools ─────────────────────────────────────────
+
+def test_e2e_includes_process_tools():
+    assert "list_processes" in E2E_TOOLS
+    assert "get_process" in E2E_TOOLS
+
+
+# ── get_mcp_client() server config ───────────────────────────────────────────
+
+def test_get_mcp_client_configures_both_servers():
+    with patch("agent.tools.MultiServerMCPClient") as mock_cls:
+        mock_cls.return_value = MagicMock()
+        get_mcp_client()
+        config = mock_cls.call_args[0][0]
+        assert "github" in config, "GitHub server missing from MCP client config"
+        assert "gitnexus" in config, "GitNexus server missing from MCP client config"
+
+
+def test_get_mcp_client_github_server_config():
+    with patch("agent.tools.MultiServerMCPClient") as mock_cls:
+        mock_cls.return_value = MagicMock()
+        get_mcp_client()
+        config = mock_cls.call_args[0][0]["github"]
+        assert config["transport"] == "stdio"
+        assert config["command"] == "npx"
+        assert "@modelcontextprotocol/server-github" in config["args"]
+
+
+def test_get_mcp_client_gitnexus_server_config():
+    with patch("agent.tools.MultiServerMCPClient") as mock_cls:
+        mock_cls.return_value = MagicMock()
+        get_mcp_client()
+        config = mock_cls.call_args[0][0]["gitnexus"]
+        assert config["transport"] == "stdio"
+        assert config["command"] == "gitnexus"
+        assert "mcp" in config["args"]
+
+
+# ── make_process_tools() ──────────────────────────────────────────────────────
+
+def test_make_process_tools_returns_two_tools():
+    tools = make_process_tools("minetest")
+    assert len(tools) == 2
+
+
+def test_make_process_tools_names():
+    tools = make_process_tools("minetest")
+    names = {t.name for t in tools}
+    assert names == {"list_processes", "get_process"}
+
+
+def test_make_process_tools_have_descriptions():
+    tools = make_process_tools("minetest")
+    for tool in tools:
+        assert tool.description and len(tool.description.strip()) > 0
+
+
+def test_make_process_tools_are_callable():
+    """Tools must be StructuredTool instances with a coroutine."""
+    tools = make_process_tools("minetest")
+    for tool in tools:
+        assert callable(tool.func) or tool.coroutine is not None
+
+
+# ── GitNexus tool coverage ────────────────────────────────────────────────────
+# Verifies that the stage subsets collectively reference all known GitNexus
+# tools. Full "16 tools returned by client.get_tools()" requires a live
+# gitnexus MCP server and is covered by manual / integration testing.
+
+def test_all_gitnexus_tools_referenced_across_stages():
+    all_stage_tools = GATHER_TOOLS | UNIT_TOOLS | INTEGRATION_TOOLS | E2E_TOOLS
+    missing = _GITNEXUS_TOOLS - all_stage_tools
+    # Tools that are available but intentionally unused in any stage
+    # (future multi-repo support, rarely used rename)
+    intentionally_unused = {"rename", "group_list", "group_sync", "group_contracts", "group_query", "group_status"}
+    missing -= intentionally_unused
+    assert not missing, f"GitNexus tools not referenced in any stage subset: {missing}"


### PR DESCRIPTION
…embeddings

  - Expose per-stage tool subsets (GATHER/UNIT/INTEGRATION/E2E) and add filter_tools() to tools.py so each stage sub-agent only accesses its allowed tools; add make_process_tools() wrapping list_processes / get_process resource URIs with Cypher fallback
  - Add prefetch.py with prefetch_context() to pre-load process list and repo stats before the agent graph starts, reducing gather-stage budget
  - Rewrite prompts.py with BASE_PROMPT + four stage-specific addenda (GATHER/UNIT/INTEGRATION/E2E), each referencing only its stage's tools and documenting its call budget; keep SYSTEM_PROMPT alias for compat
  - Add --embeddings flag to gitnexus analyze and emit "embeddings" stage in the indexer SSE stream
  - Fix pre-existing bug in _fetch_stats_and_graph: MCP client was called without entering its async context manager
  - Add test_tools, test_prefetch, test_prompts; extend test_indexer_async with embeddings flag and stage event tests (106 passing)