### PR TITLE
Danila/sprint3

### DIFF
--- a/backend/agent/bug_agent.py
+++ b/backend/agent/bug_agent.py
@@ -1,0 +1,430 @@
+"""
+Bug Reproduction Agent — StateGraph wiring + entry points.
+
+Graph:
+  triage → mechanics_analysis → checkpoint_mechanics →
+  reproduction_planning → research → checkpoint_research →
+  report_generation → END
+
+Entry points:
+  run_bug_agent()      — start a new session, stream SSE events
+  continue_bug_agent() — resume after a checkpoint interrupt
+"""
+
+import asyncio
+import os
+import traceback
+from typing import Any, AsyncIterator, Literal
+from uuid import uuid4
+
+from langchain_anthropic import ChatAnthropic
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, StateGraph
+from langgraph.types import Command, interrupt
+from pydantic import BaseModel
+
+from agent.agent import BugReproductionState
+from models import AgentStepEvent, CheckpointEvent, ErrorEvent, StageChangeEvent
+
+# ── Bug result event ──────────────────────────────────────────────────────────
+# Temporary definition — move to models.py when P3 defines BugReportResultEvent.
+
+class BugResultEvent(BaseModel):
+    type: Literal["bug_result"] = "bug_result"
+    session_id: str
+    bug_report: dict
+
+
+# ── LLM singleton ─────────────────────────────────────────────────────────────
+
+_llm = ChatAnthropic(
+    model="claude-sonnet-4-6",
+    temperature=0,
+    max_tokens=4096,
+    api_key=os.environ.get("ANTHROPIC_AUTH_TOKEN") or os.environ.get("ANTHROPIC_API_KEY"),
+    base_url=os.environ.get("ANTHROPIC_BASE_URL"),
+)
+
+# ── Stage node names (for StageChangeEvent filtering) ────────────────────────
+
+_BUG_STAGE_NODES = {
+    "triage",
+    "mechanics_analysis",
+    "checkpoint_mechanics",
+    "reproduction_planning",
+    "research",
+    "checkpoint_research",
+    "report_generation",
+}
+
+TIMEOUT_SECONDS = 600
+
+# ── Graph node wrappers ───────────────────────────────────────────────────────
+
+async def _triage_node(state: BugReproductionState) -> dict:
+    from agent.stages.bug_triage import triage_node
+    return await triage_node(state, _llm)
+
+
+async def _mechanics_node(state: BugReproductionState) -> dict:
+    from agent.stages.bug_mechanics import mechanics_node
+    return await mechanics_node(state, _llm)
+
+
+def _checkpoint_mechanics_node(state: BugReproductionState) -> dict:
+    """
+    Human-in-the-loop after mechanics analysis.
+    Exposes affected components and ranked hypotheses.
+    approve → reproduction_planning
+    refine  → back to mechanics_analysis with feedback
+    """
+    mechanics = state.get("mechanics", {})
+
+    response = interrupt({
+        "type": "checkpoint_mechanics",
+        "stage_completed": "mechanics_analysis",
+        "intermediate_result": {
+            "affected_components": mechanics.get("affected_components", []),
+            "root_cause_hypotheses": mechanics.get("root_cause_hypotheses", []),
+            "code_paths": mechanics.get("code_paths", []),
+        },
+        "prompt": (
+            "Mechanics analysis complete. Review the affected components and root cause hypotheses.\n"
+            "  approve — proceed to reproduction planning\n"
+            "  refine  — provide feedback to improve the analysis"
+        ),
+    })
+
+    action = response.get("action", "approve")
+    if action == "refine":
+        return {
+            "current_stage": "mechanics_analysis",
+            "mechanics_feedback": response.get("feedback", ""),
+        }
+    return {
+        "current_stage": "reproduction_planning",
+        "mechanics_feedback": None,
+    }
+
+
+async def _reproduction_node(state: BugReproductionState) -> dict:
+    from agent.stages.bug_reproduction import reproduction_node
+    return await reproduction_node(state, _llm)
+
+
+async def _research_node(state: BugReproductionState) -> dict:
+    from agent.stages.bug_research import research_node
+    return await research_node(state, _llm)
+
+
+def _checkpoint_research_node(state: BugReproductionState) -> dict:
+    """
+    Human-in-the-loop after research.
+    Exposes evidence summary.
+    approve      → report_generation
+    add_context  → back to research with extra context
+    """
+    findings = state.get("research_findings", {})
+
+    response = interrupt({
+        "type": "checkpoint_research",
+        "stage_completed": "research",
+        "intermediate_result": {
+            "sources_queried": findings.get("sources_queried", []),
+            "sources_with_results": findings.get("sources_with_results", []),
+            "related_issues_count": len(findings.get("related_issues", [])),
+            "log_entries_count": len(findings.get("log_entries", [])),
+            "doc_references_count": len(findings.get("doc_references", [])),
+        },
+        "prompt": (
+            "Research complete. Review the evidence summary.\n"
+            "  approve      — proceed to report generation\n"
+            "  add_context  — provide additional context to expand the research"
+        ),
+    })
+
+    action = response.get("action", "approve")
+    if action == "add_context":
+        return {
+            "current_stage": "research",
+            "research_context": response.get("context", ""),
+        }
+    return {
+        "current_stage": "report_generation",
+        "research_context": None,
+    }
+
+
+async def _report_node(state: BugReproductionState) -> dict:
+    from agent.stages.bug_report import report_node
+    return await report_node(state, _llm)
+
+
+# ── Routers ───────────────────────────────────────────────────────────────────
+
+def _mechanics_router(state: BugReproductionState) -> str:
+    return state.get("current_stage", "reproduction_planning")
+
+
+def _research_router(state: BugReproductionState) -> str:
+    return state.get("current_stage", "report_generation")
+
+
+# ── Graph builder ─────────────────────────────────────────────────────────────
+
+def build_bug_graph():
+    graph = StateGraph(BugReproductionState)
+
+    graph.add_node("triage", _triage_node)
+    graph.add_node("mechanics_analysis", _mechanics_node)
+    graph.add_node("checkpoint_mechanics", _checkpoint_mechanics_node)
+    graph.add_node("reproduction_planning", _reproduction_node)
+    graph.add_node("research", _research_node)
+    graph.add_node("checkpoint_research", _checkpoint_research_node)
+    graph.add_node("report_generation", _report_node)
+
+    graph.set_entry_point("triage")
+    graph.add_edge("triage", "mechanics_analysis")
+    graph.add_edge("mechanics_analysis", "checkpoint_mechanics")
+
+    graph.add_conditional_edges(
+        "checkpoint_mechanics",
+        _mechanics_router,
+        {
+            "mechanics_analysis": "mechanics_analysis",
+            "reproduction_planning": "reproduction_planning",
+        },
+    )
+
+    graph.add_edge("reproduction_planning", "research")
+    graph.add_edge("research", "checkpoint_research")
+
+    graph.add_conditional_edges(
+        "checkpoint_research",
+        _research_router,
+        {
+            "research": "research",
+            "report_generation": "report_generation",
+        },
+    )
+
+    graph.add_edge("report_generation", END)
+
+    return graph.compile(checkpointer=MemorySaver())
+
+
+# ── Graph singleton ───────────────────────────────────────────────────────────
+# Single MemorySaver instance must be shared across run and continue calls
+# so checkpoint state persists between the initial run and all resumes.
+
+_bug_graph_instance = None
+
+
+def _get_bug_graph():
+    global _bug_graph_instance
+    if _bug_graph_instance is None:
+        _bug_graph_instance = build_bug_graph()
+    return _bug_graph_instance
+
+
+# ── Session store ─────────────────────────────────────────────────────────────
+
+_bug_sessions: dict[str, dict] = {}
+
+
+# ── Entry points ──────────────────────────────────────────────────────────────
+
+async def run_bug_agent(
+    description: str,
+    environment: str | None = None,
+    severity_input: str | None = None,
+    repo_name: str | None = None,
+    jira_ticket: str | None = None,
+    attachments: list[str] | None = None,
+    session_id: str | None = None,
+) -> AsyncIterator[AgentStepEvent | StageChangeEvent | CheckpointEvent | BugResultEvent | ErrorEvent]:
+    """
+    Start a new bug reproduction session.
+    Streams SSE events until the graph completes or hits a checkpoint interrupt.
+    Called by POST /bug-report (P3 wires the endpoint).
+    """
+    try:
+        async with asyncio.timeout(TIMEOUT_SECONDS):
+            async for event in _start_bug_graph(
+                description, environment, severity_input,
+                repo_name, jira_ticket, attachments or [], session_id,
+            ):
+                yield event
+    except TimeoutError:
+        yield ErrorEvent(message=f"Bug reproduction timed out after {TIMEOUT_SECONDS} seconds.")
+    except Exception as exc:
+        traceback.print_exc()
+        yield ErrorEvent(message=f"Unexpected error during bug reproduction: {exc}")
+
+
+async def continue_bug_agent(
+    session_id: str,
+    user_response: dict,
+) -> AsyncIterator[AgentStepEvent | StageChangeEvent | CheckpointEvent | BugResultEvent | ErrorEvent]:
+    """
+    Resume a bug reproduction graph paused at a checkpoint interrupt.
+    Called by POST /bug-report/{session_id}/continue (P3 wires the endpoint).
+    user_response examples:
+      {"action": "approve"}
+      {"action": "refine", "feedback": "Focus on the save serialization path"}
+      {"action": "add_context", "context": "This only started after the 2.4 patch"}
+    """
+    try:
+        async with asyncio.timeout(TIMEOUT_SECONDS):
+            async for event in _resume_bug_graph(session_id, user_response):
+                yield event
+    except TimeoutError:
+        yield ErrorEvent(message=f"Bug reproduction resume timed out after {TIMEOUT_SECONDS} seconds.")
+    except Exception as exc:
+        traceback.print_exc()
+        yield ErrorEvent(message=f"Unexpected error during bug reproduction resume: {exc}")
+
+
+# ── Internal graph drivers ────────────────────────────────────────────────────
+
+async def _start_bug_graph(
+    description: str,
+    environment: str | None,
+    severity_input: str | None,
+    repo_name: str | None,
+    jira_ticket: str | None,
+    attachments: list[str],
+    session_id: str | None,
+) -> AsyncIterator[AgentStepEvent | StageChangeEvent | CheckpointEvent | BugResultEvent | ErrorEvent]:
+    thread_id = session_id or str(uuid4())
+    config = {"configurable": {"thread_id": thread_id}, "recursion_limit": 100}
+
+    initial_state: BugReproductionState = {
+        "description": description,
+        "environment": environment,
+        "severity_input": severity_input,
+        "repo_name": repo_name,
+        "jira_ticket": jira_ticket,
+        "attachments": attachments,
+        "session_id": thread_id,
+        "repo_stats": {},
+        "processes": [],
+        "triage": {},
+        "mechanics": {},
+        "reproduction_plan": {},
+        "research_findings": {},
+        "bug_report": {},
+        "current_stage": "triage",
+        "tool_calls_used": 0,
+        "messages": [],
+        "available_tools": [],
+        "mechanics_feedback": None,
+        "research_context": None,
+    }
+
+    _bug_sessions[thread_id] = {"description": description, "repo_name": repo_name}
+
+    async for event in _stream_bug_graph(_get_bug_graph(), initial_state, config, thread_id):
+        yield event
+
+
+async def _resume_bug_graph(
+    session_id: str,
+    user_response: dict,
+) -> AsyncIterator[AgentStepEvent | StageChangeEvent | CheckpointEvent | BugResultEvent | ErrorEvent]:
+    if session_id not in _bug_sessions:
+        yield ErrorEvent(message=f"Bug session {session_id!r} not found.")
+        return
+
+    config = {"configurable": {"thread_id": session_id}, "recursion_limit": 100}
+
+    async for event in _stream_bug_graph(
+        _get_bug_graph(), Command(resume=user_response), config, session_id
+    ):
+        yield event
+
+
+async def _stream_bug_graph(
+    graph: Any,
+    input_or_command: Any,
+    config: dict,
+    thread_id: str,
+) -> AsyncIterator[AgentStepEvent | StageChangeEvent | CheckpointEvent | BugResultEvent | ErrorEvent]:
+    """Drive the bug graph, mapping LangGraph events to SSE events."""
+    emitted_stages: set[str] = set()
+
+    async for event in graph.astream_events(input_or_command, version="v2", config=config):
+        event_type = event["event"]
+        node_name = event.get("metadata", {}).get("langgraph_node", "")
+
+        if event_type == "on_chain_start" and node_name in _BUG_STAGE_NODES:
+            if node_name not in emitted_stages:
+                emitted_stages.add(node_name)
+                yield StageChangeEvent(
+                    stage=node_name,
+                    summary=f"Starting {node_name.replace('_', ' ')}",
+                )
+
+        elif event_type == "on_tool_start":
+            tool_name = event["name"]
+            tool_input = event["data"].get("input", {})
+            yield AgentStepEvent(tool=tool_name, summary=_bug_tool_summary(tool_name, tool_input))
+
+    # Stream ended — check for interrupt or completion
+    state = await graph.aget_state(config)
+
+    if state.next:
+        interrupt_values = [
+            intr.value
+            for task in state.tasks
+            for intr in getattr(task, "interrupts", [])
+        ]
+        payload = interrupt_values[0] if interrupt_values else {}
+        yield CheckpointEvent(
+            session_id=thread_id,
+            stage_completed=state.values.get("current_stage", "unknown"),
+            interrupt_type=payload.get("type", "checkpoint"),
+            payload=payload,
+        )
+    else:
+        bug_report = state.values.get("bug_report", {})
+        if not bug_report:
+            yield ErrorEvent(message="Bug reproduction completed but produced no report.")
+            return
+        yield BugResultEvent(session_id=thread_id, bug_report=bug_report)
+
+
+# ── Tool summary builders ─────────────────────────────────────────────────────
+
+def _bug_tool_summary(tool_name: str, tool_input: dict) -> str:
+    builders = {
+        "jira_search": lambda i: f"Searching Jira: {i.get('query', '')}",
+        "jira_get_issue": lambda i: f"Fetching Jira issue: {i.get('issue_key', '')}",
+        "jira_get_comments": lambda i: f"Reading comments on: {i.get('issue_key', '')}",
+        "jira_create_issue": lambda i: f"Creating Jira issue: {i.get('summary', '')}",
+        "jira_update_issue": lambda i: f"Updating Jira issue: {i.get('issue_key', '')}",
+        "notion_search": lambda i: f"Searching Notion: {i.get('query', '')}",
+        "notion_get_page": lambda i: f"Reading Notion page: {i.get('page_id', '')}",
+        "confluence_search": lambda i: f"Searching Confluence: {i.get('query', '')}",
+        "confluence_get_page": lambda i: f"Reading Confluence page: {i.get('page_id', '')}",
+        "grafana_query_logs": lambda i: f"Querying Grafana logs: {i.get('query', '')}",
+        "kibana_search": lambda i: f"Searching Kibana: {i.get('query', '')}",
+        "sniffer_parse_har": lambda i: f"Parsing HAR file: {i.get('file_path', '')}",
+        "sniffer_find_errors": lambda i: f"Finding errors in: {i.get('file_path', '')}",
+        "get_file_contents": lambda i: f"Reading file: {i.get('path', i.get('file_path', ''))}",
+        "search_code": lambda i: f"Searching code: {i.get('query', '')}",
+        "impact": lambda i: f"Checking blast radius: {i.get('target', i.get('file', ''))}",
+        "context": lambda i: f"Getting context for: {i.get('name', '')}",
+        "query": lambda i: f"Semantic search: {i.get('query', '')}",
+        "cypher": lambda i: f"Graph query: {str(i.get('query', ''))[:60]}",
+        "submit_triage": lambda _: "Submitting triage findings",
+        "submit_mechanics": lambda _: "Submitting mechanics analysis",
+        "submit_reproduction": lambda _: "Submitting reproduction plan",
+        "submit_research": lambda _: "Submitting research findings",
+        "submit_report": lambda _: "Submitting bug report",
+    }
+    try:
+        builder = builders.get(tool_name)
+        return builder(tool_input) if builder else f"Calling tool: {tool_name}"
+    except Exception:
+        return f"Calling tool: {tool_name}"

--- a/backend/agent/bug_agent.py
+++ b/backend/agent/bug_agent.py
@@ -21,7 +21,7 @@ from langchain_anthropic import ChatAnthropic
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.graph import END, StateGraph
 from langgraph.types import Command, interrupt
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from agent.agent import BugReproductionState
 from models import AgentStepEvent, CheckpointEvent, ErrorEvent, StageChangeEvent
@@ -33,6 +33,7 @@ class BugResultEvent(BaseModel):
     type: Literal["bug_result"] = "bug_result"
     session_id: str
     bug_report: dict
+    full_state: dict = Field(default_factory=dict)
 
 
 # ── LLM singleton ─────────────────────────────────────────────────────────────
@@ -109,7 +110,9 @@ def _checkpoint_mechanics_node(state: BugReproductionState) -> dict:
 
 async def _reproduction_node(state: BugReproductionState) -> dict:
     from agent.stages.bug_reproduction import reproduction_node
-    return await reproduction_node(state, _llm, _run_clients.get(state["session_id"]))
+    client = _run_clients.get(state["session_id"])
+    print(f"[_reproduction_node] session_id={state['session_id']!r} client_present={client is not None}", flush=True)
+    return await reproduction_node(state, _llm, client)
 
 
 async def _research_node(state: BugReproductionState) -> dict:
@@ -328,7 +331,7 @@ async def _start_bug_graph(
         "research_context": None,
     }
 
-    _bug_sessions[thread_id] = {"description": description, "repo_name": repo_name}
+    _bug_sessions[thread_id] = {"description": description, "repo_name": repo_name, "emitted_stages": set()}
 
     from agent.tools import get_mcp_client
     print("[bug_agent] starting shared MCP client...", flush=True)
@@ -370,7 +373,9 @@ async def _stream_bug_graph(
     thread_id: str,
 ) -> AsyncIterator[AgentStepEvent | StageChangeEvent | CheckpointEvent | BugResultEvent | ErrorEvent]:
     """Drive the bug graph, mapping LangGraph events to SSE events."""
-    emitted_stages: set[str] = set()
+    # Load emitted_stages from session so resume calls don't re-emit already-seen stages (Bug #3)
+    session = _bug_sessions.get(thread_id, {})
+    emitted_stages: set[str] = session.get("emitted_stages", set())
 
     async for event in graph.astream_events(input_or_command, version="v2", config=config):
         event_type = event["event"]
@@ -379,6 +384,8 @@ async def _stream_bug_graph(
         if event_type == "on_chain_start" and node_name in _BUG_STAGE_NODES:
             if node_name not in emitted_stages:
                 emitted_stages.add(node_name)
+                if thread_id in _bug_sessions:
+                    _bug_sessions[thread_id]["emitted_stages"] = emitted_stages
                 yield StageChangeEvent(
                     stage=node_name,
                     summary=f"Starting {node_name.replace('_', ' ')}",
@@ -401,7 +408,9 @@ async def _stream_bug_graph(
         payload = interrupt_values[0] if interrupt_values else {}
         yield CheckpointEvent(
             session_id=thread_id,
-            stage_completed=state.values.get("current_stage", "unknown"),
+            # Use the interrupt payload's stage_completed — state.current_stage already
+            # points to the NEXT stage by the time we read it (Bug #2)
+            stage_completed=payload.get("stage_completed", state.values.get("current_stage", "unknown")),
             interrupt_type=payload.get("type", "checkpoint"),
             payload=payload,
         )
@@ -410,7 +419,11 @@ async def _stream_bug_graph(
         if not bug_report:
             yield ErrorEvent(message="Bug reproduction completed but produced no report.")
             return
-        yield BugResultEvent(session_id=thread_id, bug_report=bug_report)
+        yield BugResultEvent(
+            session_id=thread_id,
+            bug_report=bug_report,
+            full_state=dict(state.values),
+        )
 
 
 # ── Tool summary builders ─────────────────────────────────────────────────────

--- a/backend/agent/bug_agent.py
+++ b/backend/agent/bug_agent.py
@@ -36,10 +36,20 @@ class BugResultEvent(BaseModel):
     full_state: dict = Field(default_factory=dict)
 
 
-# ── LLM singleton ─────────────────────────────────────────────────────────────
+# ── LLM singletons ────────────────────────────────────────────────────────────
+# Heavy stages (mechanics, reproduction, research) need Sonnet for deep reasoning.
+# Light stages (triage = classification, report = synthesis) run on Haiku (~37x cheaper).
 
 _llm = ChatAnthropic(
     model="claude-sonnet-4-6",
+    temperature=0,
+    max_tokens=4096,
+    api_key=os.environ.get("ANTHROPIC_AUTH_TOKEN") or os.environ.get("ANTHROPIC_API_KEY"),
+    base_url=os.environ.get("ANTHROPIC_BASE_URL"),
+)
+
+_llm_light = ChatAnthropic(
+    model="claude-haiku-4-5-20251001",
     temperature=0,
     max_tokens=4096,
     api_key=os.environ.get("ANTHROPIC_AUTH_TOKEN") or os.environ.get("ANTHROPIC_API_KEY"),
@@ -64,7 +74,7 @@ TIMEOUT_SECONDS = 600
 
 async def _triage_node(state: BugReproductionState) -> dict:
     from agent.stages.bug_triage import triage_node
-    return await triage_node(state, _llm, _run_clients.get(state["session_id"]))
+    return await triage_node(state, _llm_light, _run_clients.get(state["session_id"]))
 
 
 async def _mechanics_node(state: BugReproductionState) -> dict:
@@ -160,7 +170,7 @@ def _checkpoint_research_node(state: BugReproductionState) -> dict:
 
 async def _report_node(state: BugReproductionState) -> dict:
     from agent.stages.bug_report import report_node
-    return await report_node(state, _llm, _run_clients.get(state["session_id"]))
+    return await report_node(state, _llm_light, _run_clients.get(state["session_id"]))
 
 
 # ── Routers ───────────────────────────────────────────────────────────────────

--- a/backend/agent/bug_agent.py
+++ b/backend/agent/bug_agent.py
@@ -63,12 +63,12 @@ TIMEOUT_SECONDS = 600
 
 async def _triage_node(state: BugReproductionState) -> dict:
     from agent.stages.bug_triage import triage_node
-    return await triage_node(state, _llm)
+    return await triage_node(state, _llm, _run_clients.get(state["session_id"]))
 
 
 async def _mechanics_node(state: BugReproductionState) -> dict:
     from agent.stages.bug_mechanics import mechanics_node
-    return await mechanics_node(state, _llm)
+    return await mechanics_node(state, _llm, _run_clients.get(state["session_id"]))
 
 
 def _checkpoint_mechanics_node(state: BugReproductionState) -> dict:
@@ -109,12 +109,12 @@ def _checkpoint_mechanics_node(state: BugReproductionState) -> dict:
 
 async def _reproduction_node(state: BugReproductionState) -> dict:
     from agent.stages.bug_reproduction import reproduction_node
-    return await reproduction_node(state, _llm)
+    return await reproduction_node(state, _llm, _run_clients.get(state["session_id"]))
 
 
 async def _research_node(state: BugReproductionState) -> dict:
     from agent.stages.bug_research import research_node
-    return await research_node(state, _llm)
+    return await research_node(state, _llm, _run_clients.get(state["session_id"]))
 
 
 def _checkpoint_research_node(state: BugReproductionState) -> dict:
@@ -157,7 +157,7 @@ def _checkpoint_research_node(state: BugReproductionState) -> dict:
 
 async def _report_node(state: BugReproductionState) -> dict:
     from agent.stages.bug_report import report_node
-    return await report_node(state, _llm)
+    return await report_node(state, _llm, _run_clients.get(state["session_id"]))
 
 
 # ── Routers ───────────────────────────────────────────────────────────────────
@@ -230,6 +230,12 @@ def _get_bug_graph():
 # ── Session store ─────────────────────────────────────────────────────────────
 
 _bug_sessions: dict[str, dict] = {}
+
+# ── Shared MCP clients (one per active run, keyed by session_id) ──────────────
+# Created once in _start_bug_graph, reused across all stage nodes, cleaned up
+# after the stream ends. Eliminates repeated server spawning per stage.
+
+_run_clients: dict[str, Any] = {}
 
 
 # ── Entry points ──────────────────────────────────────────────────────────────
@@ -324,8 +330,15 @@ async def _start_bug_graph(
 
     _bug_sessions[thread_id] = {"description": description, "repo_name": repo_name}
 
-    async for event in _stream_bug_graph(_get_bug_graph(), initial_state, config, thread_id):
-        yield event
+    from agent.tools import get_mcp_client
+    print("[bug_agent] starting shared MCP client...", flush=True)
+    client = get_mcp_client()
+    _run_clients[thread_id] = client
+    try:
+        async for event in _stream_bug_graph(_get_bug_graph(), initial_state, config, thread_id):
+            yield event
+    finally:
+        _run_clients.pop(thread_id, None)
 
 
 async def _resume_bug_graph(
@@ -338,10 +351,16 @@ async def _resume_bug_graph(
 
     config = {"configurable": {"thread_id": session_id}, "recursion_limit": 100}
 
-    async for event in _stream_bug_graph(
-        _get_bug_graph(), Command(resume=user_response), config, session_id
-    ):
-        yield event
+    from agent.tools import get_mcp_client
+    client = get_mcp_client()
+    _run_clients[session_id] = client
+    try:
+        async for event in _stream_bug_graph(
+            _get_bug_graph(), Command(resume=user_response), config, session_id
+        ):
+            yield event
+    finally:
+        _run_clients.pop(session_id, None)
 
 
 async def _stream_bug_graph(

--- a/backend/agent/prompts.py
+++ b/backend/agent/prompts.py
@@ -515,7 +515,7 @@ This is a synthesis stage — use tools only if a Jira push is needed.
 2. Synthesize a `BugReport` with ALL of the following fields:
 
    - `title` — one concise sentence describing the bug (e.g. "Fast Travel wipes equipped items via InventoryManager.reset")
-   - `severity` — from triage: critical | high | medium | low
+   - `severity` — copy EXACTLY from triage output. Do not adjust, override, or downgrade it.
    - `affected_components` — list of component/module names from mechanics
    - `root_cause` — 2-3 sentence plain-English explanation backed by the top hypothesis + evidence
    - `reproduction_steps` — the ordered steps list from reproduction_plan (copy as-is)

--- a/backend/agent/prompts.py
+++ b/backend/agent/prompts.py
@@ -433,6 +433,135 @@ without reading any code.
 After 9 research calls, stop and submit with what you have.
 """
 
+BUG_RESEARCH_PROMPT = """\
+## Stage: Research
+
+**Goal:** Query all configured external sources for evidence related to this bug.
+Each source is independent — if one fails or returns nothing, continue with the rest.
+
+### Your task
+
+Work through each available source group in order. Use the triage keywords,
+affected area, and top root cause hypothesis to focus every query.
+
+**1. Jira** (if `jira_search` available)
+- Search for open or recently closed issues matching the keywords and affected area
+- Fetch the 1-2 most relevant results with `jira_get_issue` + `jira_get_comments`
+- Collect: issue id, title, url, status, relevance note
+
+**2. Documentation** (if `notion_search` / `confluence_search` available)
+- Search for pages about the affected subsystem or feature
+- Fetch the body of the most relevant page with `notion_get_page` / `confluence_get_page`
+- Collect: page title, url, relevant excerpt (1-2 sentences)
+
+**3. Logs and metrics** (if `grafana_query_logs` / `kibana_search` available)
+- Query for error messages, stack traces, or anomalies matching the bug keywords
+- Use the affected area and triage keywords as search terms
+- Collect: timestamp, level, message, source
+
+**4. Network traces** (if `sniffer_parse_har` / `sniffer_find_errors` available
+   and attachments are present in state)
+- Parse any HAR files from `attachments` and extract HTTP errors
+- Collect: request url, method, status code, error detail
+
+**5. Code graph** (if repo is indexed)
+- Use `query` for semantic search over execution flows related to the affected area
+- Use `cypher` to find processes that pass through the affected components:
+  ```
+  MATCH (p:Process)-[r:CodeRelation]->(s) WHERE r.type='STEP_IN_PROCESS'
+  AND s.name IN [<affected symbols>] RETURN p.name, s.name LIMIT 20
+  ```
+- Collect: process names, relevant symbol names
+
+### Output
+Call `submit_research` with:
+- `log_entries` — list of `{timestamp, level, message, source}` (empty list if none)
+- `doc_references` — list of `{title, url, excerpt}` (empty list if none)
+- `related_issues` — list of `{id, title, url, status, relevance}` (empty list if none)
+- `network_traces` — list of `{url, method, status_code, error}` (empty list if none)
+- `code_graph_hits` — list of `{process, symbol, note}` (empty list if none)
+- `sources_queried` — list of source names you actually attempted (e.g. ["jira", "grafana"])
+- `sources_with_results` — list of source names that returned useful data
+
+### Rules
+- Skip any source whose tools are not in your available tool list — do not error
+- One source failing must not stop the others
+- Do not retry a failed tool call — note the failure and move on
+- Prefer breadth over depth: cover all sources before going deep on any one
+
+### Allowed tools
+`cypher`, `query`, `jira_search`, `jira_get_issue`, `jira_get_comments`,
+`notion_search`, `notion_get_page`, `confluence_search`, `confluence_get_page`,
+`grafana_query_logs`, `kibana_search`, `sniffer_parse_har`, `sniffer_find_errors`
+
+### Budget: 20 tool calls maximum
+After 16 research calls, stop and call `submit_research` immediately with what you have.
+"""
+
+BUG_REPORT_PROMPT = """\
+## Stage: Report Generation
+
+**Goal:** Assemble a complete, actionable bug report from all previous stage outputs.
+This is a synthesis stage — use tools only if a Jira push is needed.
+
+### Your task
+
+1. Read all stage outputs from the conversation:
+   - `triage` — bug category, severity, affected area, similar issues
+   - `mechanics` — code paths, affected components, root cause hypotheses
+   - `reproduction_plan` — steps, prerequisites, environment requirements
+   - `research_findings` — log entries, doc references, related issues, network traces
+
+2. Synthesize a `BugReport` with ALL of the following fields:
+
+   - `title` — one concise sentence describing the bug (e.g. "Fast Travel wipes equipped items via InventoryManager.reset")
+   - `severity` — from triage: critical | high | medium | low
+   - `affected_components` — list of component/module names from mechanics
+   - `root_cause` — 2-3 sentence plain-English explanation backed by the top hypothesis + evidence
+   - `reproduction_steps` — the ordered steps list from reproduction_plan (copy as-is)
+   - `prerequisites` — from reproduction_plan
+   - `environment_requirements` — from reproduction_plan
+   - `evidence` — assembled from research_findings: relevant log entries, doc refs, related issues, network traces
+   - `recommendations` — list of 2-4 concrete fix suggestions derived from the root cause hypotheses
+   - `confidence` — overall pipeline confidence:
+     * `high` — mechanics confidence high AND reproduction confidence high AND ≥1 evidence source found
+     * `medium` — at least one of mechanics/reproduction is medium, or no external evidence
+     * `low` — mechanics or reproduction confidence low, or pipeline ran with zero tools
+
+3. If `jira_ticket` is present in the initial input AND `jira_update_issue` is available:
+   - Update the existing ticket with the report summary using `jira_update_issue`
+
+   If no `jira_ticket` AND `jira_create_issue` is available AND severity is critical or high:
+   - Create a new Jira issue with `jira_create_issue` and include the returned URL in the report
+
+4. Call `submit_report` with the completed `BugReport`.
+
+### submit_report parameters
+
+- `title` — string
+- `severity` — critical | high | medium | low
+- `affected_components` — list of strings
+- `root_cause` — string (2-3 sentences)
+- `reproduction_steps` — list of `{step_number, action, expected_result}`
+- `prerequisites` — list of strings
+- `environment_requirements` — list of strings
+- `evidence` — dict with keys: `log_entries`, `doc_references`, `related_issues`, `network_traces`
+- `recommendations` — list of strings
+- `confidence` — high | medium | low
+- `jira_url` — string or null (URL of created/updated Jira issue)
+
+### Rules
+- Do not invent data — only report what came from earlier stages and research
+- If a stage output is missing or empty, note it in the relevant field rather than guessing
+- Keep `root_cause` grounded in specific evidence (file, call chain, or log entry)
+- `recommendations` must be actionable: "Add a null-check in X before calling Y", not "fix the bug"
+
+### Allowed tools
+`jira_create_issue`, `jira_update_issue`
+
+### Budget: 5 tool calls maximum
+"""
+
 # ── Backward-compatibility alias ──────────────────────────────────────────────
 # agent.py (Sprint 1) imports SYSTEM_PROMPT. Keep this alias until Dev A's
 # StateGraph rewrite merges, at which point SYSTEM_PROMPT can be removed.

--- a/backend/agent/prompts.py
+++ b/backend/agent/prompts.py
@@ -328,7 +328,7 @@ and locate the relevant area of the codebase.
 
 ### Allowed tools
 `jira_search`, `jira_get_issue`, `jira_get_comments`, `search_code`, \
-`get_file_contents`, `cypher`, `impact`, `list_repos`
+`cypher`, `impact`, `list_repos`
 
 ### Budget: 8 tool calls maximum
 If you reach the budget before calling submit_triage, call it immediately with what you have.

--- a/backend/agent/prompts.py
+++ b/backend/agent/prompts.py
@@ -379,8 +379,8 @@ components, and produce ranked root cause hypotheses backed by evidence.
   - `evidence`: specific file, line, or call chain that supports this hypothesis
 
 ### Allowed tools
-`get_file_contents`, `search_code`, `cypher`, `context`, `impact`, \
-`detect_changes`, `list_directory`
+`get_file_contents`, `search_code`, `cypher`, `query`, `context`, `impact`, \
+`list_directory`
 
 ### Budget: 15 tool calls maximum
 After 12 research calls, stop and submit with what you have.

--- a/backend/agent/stages/bug_mechanics.py
+++ b/backend/agent/stages/bug_mechanics.py
@@ -16,7 +16,7 @@ from langgraph.prebuilt import create_react_agent
 from pydantic import BaseModel, Field
 
 from agent.prompts import BUG_BASE_PROMPT, BUG_MECHANICS_PROMPT
-from agent.tools import filter_tools, get_mcp_client, safe_tools
+from agent.tools import filter_tools, fix_dangling_tool_calls, get_mcp_client, make_messages_modifier, safe_tools
 
 if TYPE_CHECKING:
     from agent.agent import BugReproductionState
@@ -99,6 +99,7 @@ async def mechanics_node(state: "BugReproductionState", llm: Any = None, client:
         tools=stage_tools + [submit_tool],
         prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_MECHANICS_PROMPT}"),
         checkpointer=_saver,
+        pre_model_hook=make_messages_modifier(),
     )
 
     tool_call_count = 0
@@ -107,21 +108,25 @@ async def mechanics_node(state: "BugReproductionState", llm: Any = None, client:
         version="v2",
         config=_stage_config,
     ):
-        if event["event"] == "on_tool_start":
+        event_type = event["event"]
+        if event_type == "on_tool_start":
             tool_call_count += 1
             print(f"  [{tool_call_count}/{BUDGET}] {event['name']}", flush=True)
             if event["name"] != "submit_mechanics" and tool_call_count >= BUDGET:
                 break
+        elif event_type == "on_tool_end" and event.get("name") == "submit_mechanics":
+            break  # Tool finished and results is populated — stop immediately
 
     base_count = state.get("tool_calls_used", 0)
     if not results:
         print(f"  [mechanics] budget hit without submit — forcing synthesis from {tool_call_count} calls", flush=True)
         agent_state = await agent.aget_state(_stage_config)
-        accumulated = agent_state.values.get("messages", [])
+        accumulated = fix_dangling_tool_calls(agent_state.values.get("messages", []))
         submit_agent = create_react_agent(
             model=llm,
             tools=[submit_tool],
             prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_MECHANICS_PROMPT}"),
+            pre_model_hook=make_messages_modifier(),
         )
         async for _ in submit_agent.astream_events(
             {"messages": accumulated + [HumanMessage(content=(
@@ -130,7 +135,7 @@ async def mechanics_node(state: "BugReproductionState", llm: Any = None, client:
                 "Use confidence='medium' or 'low' as appropriate for what you found."
             ))]},
             version="v2",
-            config={"recursion_limit": 5},
+            config={"recursion_limit": 10},
         ):
             pass
 

--- a/backend/agent/stages/bug_mechanics.py
+++ b/backend/agent/stages/bug_mechanics.py
@@ -22,15 +22,18 @@ if TYPE_CHECKING:
 BUDGET = 15
 
 
-async def mechanics_node(state: "BugReproductionState", llm: Any = None) -> dict:
+async def mechanics_node(state: "BugReproductionState", llm: Any = None, client: Any = None) -> dict:
     if llm is None:
         from agent.agent import _llm
         llm = _llm
 
-    print("[bug_mechanics] starting MCP client...", flush=True)
-    client = get_mcp_client()
+    _own_client = client is None
+    if _own_client:
+        print("[bug_mechanics] starting MCP client...", flush=True)
+        client = get_mcp_client()
     all_tools = await client.get_tools()
-    print(f"[bug_mechanics] got {len(all_tools)} tools, filtering to bug_mechanics stage...", flush=True)
+    if _own_client:
+        print(f"[bug_mechanics] got {len(all_tools)} tools, filtering to bug_mechanics stage...", flush=True)
     stage_tools = safe_tools(filter_tools(all_tools, "bug_mechanics"))
 
     class _MechanicsOutput(BaseModel):

--- a/backend/agent/stages/bug_mechanics.py
+++ b/backend/agent/stages/bug_mechanics.py
@@ -7,9 +7,11 @@ Budget: 15 tool calls.
 """
 
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.tools import StructuredTool
+from langgraph.checkpoint.memory import MemorySaver
 from langgraph.prebuilt import create_react_agent
 from pydantic import BaseModel, Field
 
@@ -88,17 +90,22 @@ async def mechanics_node(state: "BugReproductionState", llm: Any = None, client:
         f"{repo_clause}"
     )
 
+    _saver = MemorySaver()
+    _thread = f"{state.get('session_id', 'anon')}-mechanics-{uuid4().hex[:8]}"
+    _stage_config = {"configurable": {"thread_id": _thread}, "recursion_limit": 40}
+
     agent = create_react_agent(
         model=llm,
         tools=stage_tools + [submit_tool],
         prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_MECHANICS_PROMPT}"),
+        checkpointer=_saver,
     )
 
     tool_call_count = 0
     async for event in agent.astream_events(
         {"messages": [HumanMessage(content=human_content)]},
         version="v2",
-        config={"recursion_limit": 40},
+        config=_stage_config,
     ):
         if event["event"] == "on_tool_start":
             tool_call_count += 1
@@ -107,6 +114,26 @@ async def mechanics_node(state: "BugReproductionState", llm: Any = None, client:
                 break
 
     base_count = state.get("tool_calls_used", 0)
+    if not results:
+        print(f"  [mechanics] budget hit without submit — forcing synthesis from {tool_call_count} calls", flush=True)
+        agent_state = await agent.aget_state(_stage_config)
+        accumulated = agent_state.values.get("messages", [])
+        submit_agent = create_react_agent(
+            model=llm,
+            tools=[submit_tool],
+            prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_MECHANICS_PROMPT}"),
+        )
+        async for _ in submit_agent.astream_events(
+            {"messages": accumulated + [HumanMessage(content=(
+                f"[BUDGET EXHAUSTED after {tool_call_count} tool calls] "
+                "Call submit_mechanics NOW with your findings. No more research tools available. "
+                "Use confidence='medium' or 'low' as appropriate for what you found."
+            ))]},
+            version="v2",
+            config={"recursion_limit": 5},
+        ):
+            pass
+
     if not results:
         return {
             "current_stage": "reproduction_planning",

--- a/backend/agent/stages/bug_report.py
+++ b/backend/agent/stages/bug_report.py
@@ -1,0 +1,165 @@
+"""
+Bug Stage 5: Report Generation
+
+Assembles the final BugReport from all previous stage outputs, computes
+overall confidence, and optionally pushes to Jira.
+Budget: 5 tool calls.
+"""
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.tools import StructuredTool
+from langgraph.prebuilt import create_react_agent
+from pydantic import BaseModel, Field
+
+from agent.prompts import BUG_BASE_PROMPT, BUG_REPORT_PROMPT
+from agent.tools import filter_tools, get_mcp_client, safe_tools
+
+if TYPE_CHECKING:
+    from agent.agent import BugReproductionState
+
+BUDGET = 5
+
+
+async def report_node(state: "BugReproductionState", llm: Any = None) -> dict:
+    if llm is None:
+        from agent.agent import _llm
+        llm = _llm
+
+    print("[bug_report] starting MCP client...", flush=True)
+    client = get_mcp_client()
+    all_tools = await client.get_tools()
+    print(f"[bug_report] got {len(all_tools)} tools, filtering to bug_report stage...", flush=True)
+    stage_tools = safe_tools(filter_tools(all_tools, "bug_report"))
+
+    class _ReportOutput(BaseModel):
+        title: str
+        severity: str
+        affected_components: list[str] = Field(default_factory=list)
+        root_cause: str
+        reproduction_steps: list[dict] = Field(default_factory=list)
+        prerequisites: list[str] = Field(default_factory=list)
+        environment_requirements: list[str] = Field(default_factory=list)
+        evidence: dict = Field(default_factory=dict)
+        recommendations: list[str] = Field(default_factory=list)
+        confidence: str = "low"
+        jira_url: str | None = None
+
+    results: list[_ReportOutput] = []
+
+    def submit_report(
+        title: str,
+        severity: str,
+        root_cause: str,
+        confidence: str,
+        affected_components: list = [],
+        reproduction_steps: list = [],
+        prerequisites: list = [],
+        environment_requirements: list = [],
+        evidence: dict = {},
+        recommendations: list = [],
+        jira_url: str | None = None,
+    ) -> str:
+        results.append(_ReportOutput(
+            title=title,
+            severity=severity,
+            affected_components=affected_components,
+            root_cause=root_cause,
+            reproduction_steps=reproduction_steps,
+            prerequisites=prerequisites,
+            environment_requirements=environment_requirements,
+            evidence=evidence,
+            recommendations=recommendations,
+            confidence=confidence,
+            jira_url=jira_url,
+        ))
+        return "Report submitted."
+
+    submit_tool = StructuredTool.from_function(
+        func=submit_report,
+        name="submit_report",
+        description=(
+            "Submit the completed bug report. "
+            "Pass: title (one sentence describing the bug), "
+            "severity (critical|high|medium|low), "
+            "affected_components (list of component name strings), "
+            "root_cause (2-3 sentence explanation grounded in evidence), "
+            "reproduction_steps (list of {step_number, action, expected_result}), "
+            "prerequisites (list of setup condition strings), "
+            "environment_requirements (list of platform/build requirement strings), "
+            "evidence (dict with keys: log_entries, doc_references, related_issues, network_traces), "
+            "recommendations (list of 2-4 actionable fix suggestion strings), "
+            "confidence (high|medium|low), "
+            "jira_url (URL string if a Jira issue was created/updated, otherwise null)."
+        ),
+    )
+
+    triage = state.get("triage", {})
+    mechanics = state.get("mechanics", {})
+    reproduction_plan = state.get("reproduction_plan", {})
+    research_findings = state.get("research_findings", {})
+    jira_ticket = state.get("jira_ticket")
+
+    jira_clause = (
+        f"Existing Jira ticket: {jira_ticket} — update it with `jira_update_issue` if available."
+        if jira_ticket
+        else "No existing Jira ticket — create one with `jira_create_issue` if severity is critical or high and the tool is available."
+    )
+
+    human_content = "\n".join([
+        "Assemble the final bug report from the stage outputs below.",
+        "",
+        f"=== ORIGINAL REPORT ===",
+        f"Description: {state['description']}",
+        f"Environment: {state.get('environment', 'unspecified')}",
+        f"Reported severity: {state.get('severity_input', 'unspecified')}",
+        "",
+        f"=== TRIAGE ===",
+        json.dumps(triage, indent=2) if triage else "(empty — triage did not complete)",
+        "",
+        f"=== MECHANICS ===",
+        json.dumps(mechanics, indent=2) if mechanics else "(empty — mechanics did not complete)",
+        "",
+        f"=== REPRODUCTION PLAN ===",
+        json.dumps(reproduction_plan, indent=2) if reproduction_plan else "(empty — reproduction stage did not complete)",
+        "",
+        f"=== RESEARCH FINDINGS ===",
+        json.dumps(research_findings, indent=2) if research_findings else "(empty — no external sources queried)",
+        "",
+        jira_clause,
+    ])
+
+    agent = create_react_agent(
+        model=llm,
+        tools=stage_tools + [submit_tool],
+        prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_REPORT_PROMPT}"),
+    )
+
+    tool_call_count = 0
+    async for event in agent.astream_events(
+        {"messages": [HumanMessage(content=human_content)]},
+        version="v2",
+        config={"recursion_limit": 20},
+    ):
+        if event["event"] == "on_tool_start":
+            tool_call_count += 1
+            print(f"  [{tool_call_count}/{BUDGET}] {event['name']}", flush=True)
+            if event["name"] != "submit_report" and tool_call_count >= BUDGET:
+                break
+
+    base_count = state.get("tool_calls_used", 0)
+    if not results:
+        return {
+            "current_stage": "done",
+            "tool_calls_used": base_count + tool_call_count,
+            "bug_report": {},
+        }
+
+    r = results[-1]
+    return {
+        "current_stage": "done",
+        "tool_calls_used": base_count + tool_call_count,
+        "bug_report": r.model_dump(),
+    }

--- a/backend/agent/stages/bug_report.py
+++ b/backend/agent/stages/bug_report.py
@@ -8,9 +8,11 @@ Budget: 5 tool calls.
 
 import json
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.tools import StructuredTool
+from langgraph.checkpoint.memory import MemorySaver
 from langgraph.prebuilt import create_react_agent
 from pydantic import BaseModel, Field
 
@@ -134,17 +136,22 @@ async def report_node(state: "BugReproductionState", llm: Any = None, client: An
         jira_clause,
     ])
 
+    _saver = MemorySaver()
+    _thread = f"{state.get('session_id', 'anon')}-report-{uuid4().hex[:8]}"
+    _stage_config = {"configurable": {"thread_id": _thread}, "recursion_limit": 20}
+
     agent = create_react_agent(
         model=llm,
         tools=stage_tools + [submit_tool],
         prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_REPORT_PROMPT}"),
+        checkpointer=_saver,
     )
 
     tool_call_count = 0
     async for event in agent.astream_events(
         {"messages": [HumanMessage(content=human_content)]},
         version="v2",
-        config={"recursion_limit": 20},
+        config=_stage_config,
     ):
         if event["event"] == "on_tool_start":
             tool_call_count += 1
@@ -153,6 +160,26 @@ async def report_node(state: "BugReproductionState", llm: Any = None, client: An
                 break
 
     base_count = state.get("tool_calls_used", 0)
+    if not results:
+        print(f"  [report] budget hit without submit — forcing synthesis from {tool_call_count} calls", flush=True)
+        agent_state = await agent.aget_state(_stage_config)
+        accumulated = agent_state.values.get("messages", [])
+        submit_agent = create_react_agent(
+            model=llm,
+            tools=[submit_tool],
+            prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_REPORT_PROMPT}"),
+        )
+        async for _ in submit_agent.astream_events(
+            {"messages": accumulated + [HumanMessage(content=(
+                f"[BUDGET EXHAUSTED after {tool_call_count} tool calls] "
+                "Call submit_report NOW with a complete bug report. "
+                "Use confidence='low' and note any missing data."
+            ))]},
+            version="v2",
+            config={"recursion_limit": 5},
+        ):
+            pass
+
     if not results:
         return {
             "current_stage": "done",

--- a/backend/agent/stages/bug_report.py
+++ b/backend/agent/stages/bug_report.py
@@ -17,7 +17,7 @@ from langgraph.prebuilt import create_react_agent
 from pydantic import BaseModel, Field
 
 from agent.prompts import BUG_BASE_PROMPT, BUG_REPORT_PROMPT
-from agent.tools import filter_tools, get_mcp_client, safe_tools
+from agent.tools import filter_tools, fix_dangling_tool_calls, get_mcp_client, make_messages_modifier, safe_tools
 
 if TYPE_CHECKING:
     from agent.agent import BugReproductionState
@@ -145,6 +145,7 @@ async def report_node(state: "BugReproductionState", llm: Any = None, client: An
         tools=stage_tools + [submit_tool],
         prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_REPORT_PROMPT}"),
         checkpointer=_saver,
+        pre_model_hook=make_messages_modifier(),
     )
 
     tool_call_count = 0
@@ -153,21 +154,25 @@ async def report_node(state: "BugReproductionState", llm: Any = None, client: An
         version="v2",
         config=_stage_config,
     ):
-        if event["event"] == "on_tool_start":
+        event_type = event["event"]
+        if event_type == "on_tool_start":
             tool_call_count += 1
             print(f"  [{tool_call_count}/{BUDGET}] {event['name']}", flush=True)
             if event["name"] != "submit_report" and tool_call_count >= BUDGET:
                 break
+        elif event_type == "on_tool_end" and event.get("name") == "submit_report":
+            break
 
     base_count = state.get("tool_calls_used", 0)
     if not results:
         print(f"  [report] budget hit without submit — forcing synthesis from {tool_call_count} calls", flush=True)
         agent_state = await agent.aget_state(_stage_config)
-        accumulated = agent_state.values.get("messages", [])
+        accumulated = fix_dangling_tool_calls(agent_state.values.get("messages", []))
         submit_agent = create_react_agent(
             model=llm,
             tools=[submit_tool],
             prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_REPORT_PROMPT}"),
+            pre_model_hook=make_messages_modifier(),
         )
         async for _ in submit_agent.astream_events(
             {"messages": accumulated + [HumanMessage(content=(
@@ -176,7 +181,7 @@ async def report_node(state: "BugReproductionState", llm: Any = None, client: An
                 "Use confidence='low' and note any missing data."
             ))]},
             version="v2",
-            config={"recursion_limit": 5},
+            config={"recursion_limit": 10},
         ):
             pass
 

--- a/backend/agent/stages/bug_report.py
+++ b/backend/agent/stages/bug_report.py
@@ -23,15 +23,18 @@ if TYPE_CHECKING:
 BUDGET = 5
 
 
-async def report_node(state: "BugReproductionState", llm: Any = None) -> dict:
+async def report_node(state: "BugReproductionState", llm: Any = None, client: Any = None) -> dict:
     if llm is None:
         from agent.agent import _llm
         llm = _llm
 
-    print("[bug_report] starting MCP client...", flush=True)
-    client = get_mcp_client()
+    _own_client = client is None
+    if _own_client:
+        print("[bug_report] starting MCP client...", flush=True)
+        client = get_mcp_client()
     all_tools = await client.get_tools()
-    print(f"[bug_report] got {len(all_tools)} tools, filtering to bug_report stage...", flush=True)
+    if _own_client:
+        print(f"[bug_report] got {len(all_tools)} tools, filtering to bug_report stage...", flush=True)
     stage_tools = safe_tools(filter_tools(all_tools, "bug_report"))
 
     class _ReportOutput(BaseModel):

--- a/backend/agent/stages/bug_reproduction.py
+++ b/backend/agent/stages/bug_reproduction.py
@@ -22,15 +22,18 @@ if TYPE_CHECKING:
 BUDGET = 12
 
 
-async def reproduction_node(state: "BugReproductionState", llm: Any = None) -> dict:
+async def reproduction_node(state: "BugReproductionState", llm: Any = None, client: Any = None) -> dict:
     if llm is None:
         from agent.agent import _llm
         llm = _llm
 
-    print("[bug_reproduction] starting MCP client...", flush=True)
-    client = get_mcp_client()
+    _own_client = client is None
+    if _own_client:
+        print("[bug_reproduction] starting MCP client...", flush=True)
+        client = get_mcp_client()
     all_tools = await client.get_tools()
-    print(f"[bug_reproduction] got {len(all_tools)} tools, filtering to bug_reproduction stage...", flush=True)
+    if _own_client:
+        print(f"[bug_reproduction] got {len(all_tools)} tools, filtering to bug_reproduction stage...", flush=True)
     stage_tools = safe_tools(filter_tools(all_tools, "bug_reproduction"))
 
     class _ReproductionOutput(BaseModel):

--- a/backend/agent/stages/bug_reproduction.py
+++ b/backend/agent/stages/bug_reproduction.py
@@ -16,7 +16,7 @@ from langgraph.prebuilt import create_react_agent
 from pydantic import BaseModel, Field
 
 from agent.prompts import BUG_BASE_PROMPT, BUG_REPRODUCTION_PROMPT
-from agent.tools import filter_tools, get_mcp_client, safe_tools
+from agent.tools import filter_tools, fix_dangling_tool_calls, get_mcp_client, make_messages_modifier, safe_tools
 
 if TYPE_CHECKING:
     from agent.agent import BugReproductionState
@@ -111,6 +111,7 @@ async def reproduction_node(state: "BugReproductionState", llm: Any = None, clie
         tools=stage_tools + [submit_tool],
         prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_REPRODUCTION_PROMPT}"),
         checkpointer=_saver,
+        pre_model_hook=make_messages_modifier(),
     )
 
     tool_call_count = 0
@@ -119,21 +120,25 @@ async def reproduction_node(state: "BugReproductionState", llm: Any = None, clie
         version="v2",
         config=_stage_config,
     ):
-        if event["event"] == "on_tool_start":
+        event_type = event["event"]
+        if event_type == "on_tool_start":
             tool_call_count += 1
             print(f"  [{tool_call_count}/{BUDGET}] {event['name']}", flush=True)
             if event["name"] != "submit_reproduction" and tool_call_count >= BUDGET:
                 break
+        elif event_type == "on_tool_end" and event.get("name") == "submit_reproduction":
+            break
 
     base_count = state.get("tool_calls_used", 0)
     if not results:
         print(f"  [reproduction] budget hit without submit — forcing synthesis from {tool_call_count} calls", flush=True)
         agent_state = await agent.aget_state(_stage_config)
-        accumulated = agent_state.values.get("messages", [])
+        accumulated = fix_dangling_tool_calls(agent_state.values.get("messages", []))
         submit_agent = create_react_agent(
             model=llm,
             tools=[submit_tool],
             prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_REPRODUCTION_PROMPT}"),
+            pre_model_hook=make_messages_modifier(),
         )
         async for _ in submit_agent.astream_events(
             {"messages": accumulated + [HumanMessage(content=(
@@ -142,7 +147,7 @@ async def reproduction_node(state: "BugReproductionState", llm: Any = None, clie
                 "Use confidence='low' if you couldn't fully verify all steps."
             ))]},
             version="v2",
-            config={"recursion_limit": 5},
+            config={"recursion_limit": 10},
         ):
             pass
 

--- a/backend/agent/stages/bug_reproduction.py
+++ b/backend/agent/stages/bug_reproduction.py
@@ -7,9 +7,11 @@ Budget: 12 tool calls.
 """
 
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.tools import StructuredTool
+from langgraph.checkpoint.memory import MemorySaver
 from langgraph.prebuilt import create_react_agent
 from pydantic import BaseModel, Field
 
@@ -100,17 +102,22 @@ async def reproduction_node(state: "BugReproductionState", llm: Any = None, clie
         f"{repo_clause}"
     )
 
+    _saver = MemorySaver()
+    _thread = f"{state.get('session_id', 'anon')}-reproduction-{uuid4().hex[:8]}"
+    _stage_config = {"configurable": {"thread_id": _thread}, "recursion_limit": 40}
+
     agent = create_react_agent(
         model=llm,
         tools=stage_tools + [submit_tool],
         prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_REPRODUCTION_PROMPT}"),
+        checkpointer=_saver,
     )
 
     tool_call_count = 0
     async for event in agent.astream_events(
         {"messages": [HumanMessage(content=human_content)]},
         version="v2",
-        config={"recursion_limit": 40},
+        config=_stage_config,
     ):
         if event["event"] == "on_tool_start":
             tool_call_count += 1
@@ -119,6 +126,26 @@ async def reproduction_node(state: "BugReproductionState", llm: Any = None, clie
                 break
 
     base_count = state.get("tool_calls_used", 0)
+    if not results:
+        print(f"  [reproduction] budget hit without submit — forcing synthesis from {tool_call_count} calls", flush=True)
+        agent_state = await agent.aget_state(_stage_config)
+        accumulated = agent_state.values.get("messages", [])
+        submit_agent = create_react_agent(
+            model=llm,
+            tools=[submit_tool],
+            prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_REPRODUCTION_PROMPT}"),
+        )
+        async for _ in submit_agent.astream_events(
+            {"messages": accumulated + [HumanMessage(content=(
+                f"[BUDGET EXHAUSTED after {tool_call_count} tool calls] "
+                "Call submit_reproduction NOW with your findings. No more research tools available. "
+                "Use confidence='low' if you couldn't fully verify all steps."
+            ))]},
+            version="v2",
+            config={"recursion_limit": 5},
+        ):
+            pass
+
     if not results:
         return {
             "current_stage": "research",

--- a/backend/agent/stages/bug_research.py
+++ b/backend/agent/stages/bug_research.py
@@ -1,0 +1,194 @@
+"""
+Bug Stage 4: Research
+
+Queries all configured external sources (Jira, Notion, Confluence, Grafana,
+Kibana, Sniffer, code graph) for evidence related to the bug.
+Each source is independent — one failure does not stop the rest.
+Budget: 20 tool calls.
+"""
+
+from typing import TYPE_CHECKING, Any
+
+from langchain_core.messages import HumanMessage, SystemMessage
+from langchain_core.tools import StructuredTool
+from langgraph.prebuilt import create_react_agent
+from pydantic import BaseModel, Field
+
+from agent.prompts import BUG_BASE_PROMPT, BUG_RESEARCH_PROMPT
+from agent.tools import filter_tools, get_mcp_client, safe_tools
+
+if TYPE_CHECKING:
+    from agent.agent import BugReproductionState
+
+BUDGET = 20
+
+
+async def research_node(state: "BugReproductionState", llm: Any = None) -> dict:
+    if llm is None:
+        from agent.agent import _llm
+        llm = _llm
+
+    print("[bug_research] starting MCP client...", flush=True)
+    client = get_mcp_client()
+    all_tools = await client.get_tools()
+    print(f"[bug_research] got {len(all_tools)} tools, filtering to bug_research stage...", flush=True)
+    stage_tools = safe_tools(filter_tools(all_tools, "bug_research"))
+
+    available_tool_names = {t.name for t in stage_tools}
+
+    class _ResearchOutput(BaseModel):
+        log_entries: list[dict] = Field(default_factory=list)
+        doc_references: list[dict] = Field(default_factory=list)
+        related_issues: list[dict] = Field(default_factory=list)
+        network_traces: list[dict] = Field(default_factory=list)
+        code_graph_hits: list[dict] = Field(default_factory=list)
+        sources_queried: list[str] = Field(default_factory=list)
+        sources_with_results: list[str] = Field(default_factory=list)
+
+    results: list[_ResearchOutput] = []
+
+    def submit_research(
+        log_entries: list = [],
+        doc_references: list = [],
+        related_issues: list = [],
+        network_traces: list = [],
+        code_graph_hits: list = [],
+        sources_queried: list = [],
+        sources_with_results: list = [],
+    ) -> str:
+        results.append(_ResearchOutput(
+            log_entries=log_entries,
+            doc_references=doc_references,
+            related_issues=related_issues,
+            network_traces=network_traces,
+            code_graph_hits=code_graph_hits,
+            sources_queried=sources_queried,
+            sources_with_results=sources_with_results,
+        ))
+        return "Research complete."
+
+    submit_tool = StructuredTool.from_function(
+        func=submit_research,
+        name="submit_research",
+        description=(
+            "Submit all research findings when done. "
+            "Pass: log_entries (list of {timestamp, level, message, source}), "
+            "doc_references (list of {title, url, excerpt}), "
+            "related_issues (list of {id, title, url, status, relevance}), "
+            "network_traces (list of {url, method, status_code, error}), "
+            "code_graph_hits (list of {process, symbol, note}), "
+            "sources_queried (list of source name strings you attempted), "
+            "sources_with_results (list of source names that returned useful data). "
+            "Use empty lists for sources with no results — never omit a field."
+        ),
+    )
+
+    triage = state.get("triage", {})
+    mechanics = state.get("mechanics", {})
+
+    keywords = triage.get("keywords", [])
+    affected_area = triage.get("affected_area", "unknown")
+
+    top_hypothesis = ""
+    hypotheses = mechanics.get("root_cause_hypotheses", [])
+    if hypotheses:
+        top_hypothesis = hypotheses[0].get("hypothesis", "")
+
+    affected_components = mechanics.get("affected_components", [])
+
+    repo_name = state.get("repo_name")
+    repo_clause = (
+        f'Repo "{repo_name}" is indexed in GitNexus. '
+        f"Use `query` and `cypher` to find processes and symbols in the affected area."
+        if repo_name
+        else "No indexed repo — skip GitNexus tools."
+    )
+
+    attachments = state.get("attachments", [])
+    attachment_clause = (
+        f"Attachments available for sniffer: {', '.join(attachments)}"
+        if attachments
+        else "No attachments provided — skip sniffer tools."
+    )
+
+    research_context = state.get("research_context")
+    context_clause = (
+        f"\nAdditional context from reviewer: {research_context}"
+        if research_context
+        else ""
+    )
+
+    available_sources = _available_sources(available_tool_names)
+    sources_clause = (
+        f"Available sources for this run: {', '.join(available_sources)}"
+        if available_sources
+        else "No external sources are configured — use code graph only."
+    )
+
+    human_content = "\n".join(filter(None, [
+        "Research evidence for this bug:",
+        "",
+        f"Description: {state['description']}",
+        f"Affected area: {affected_area}",
+        f"Keywords: {', '.join(keywords) if keywords else 'none'}",
+        f"Affected components: {', '.join(affected_components) if affected_components else 'none'}",
+        f"Top hypothesis: {top_hypothesis}" if top_hypothesis else "",
+        repo_clause,
+        attachment_clause,
+        sources_clause,
+        context_clause,
+    ]))
+
+    agent = create_react_agent(
+        model=llm,
+        tools=stage_tools + [submit_tool],
+        prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_RESEARCH_PROMPT}"),
+    )
+
+    tool_call_count = 0
+    async for event in agent.astream_events(
+        {"messages": [HumanMessage(content=human_content)]},
+        version="v2",
+        config={"recursion_limit": 50},
+    ):
+        if event["event"] == "on_tool_start":
+            tool_call_count += 1
+            tool_name = event["name"]
+            print(f"  [{tool_call_count}/{BUDGET}] {tool_name}", flush=True)
+            if tool_name != "submit_research" and tool_call_count >= BUDGET:
+                break
+
+    base_count = state.get("tool_calls_used", 0)
+    if not results:
+        return {
+            "current_stage": "report_generation",
+            "tool_calls_used": base_count + tool_call_count,
+            "research_findings": {},
+        }
+
+    r = results[-1]
+    return {
+        "current_stage": "report_generation",
+        "tool_calls_used": base_count + tool_call_count,
+        "research_findings": r.model_dump(),
+    }
+
+
+def _available_sources(tool_names: set[str]) -> list[str]:
+    """Returns human-readable source names based on which tools are present."""
+    sources = []
+    if tool_names & {"jira_search", "jira_get_issue"}:
+        sources.append("Jira")
+    if tool_names & {"notion_search", "notion_get_page"}:
+        sources.append("Notion")
+    if tool_names & {"confluence_search", "confluence_get_page"}:
+        sources.append("Confluence")
+    if "grafana_query_logs" in tool_names:
+        sources.append("Grafana")
+    if "kibana_search" in tool_names:
+        sources.append("Kibana")
+    if tool_names & {"sniffer_parse_har", "sniffer_find_errors"}:
+        sources.append("Sniffer")
+    if tool_names & {"cypher", "query"}:
+        sources.append("code graph")
+    return sources

--- a/backend/agent/stages/bug_research.py
+++ b/backend/agent/stages/bug_research.py
@@ -17,7 +17,7 @@ from langgraph.prebuilt import create_react_agent
 from pydantic import BaseModel, Field
 
 from agent.prompts import BUG_BASE_PROMPT, BUG_RESEARCH_PROMPT
-from agent.tools import filter_tools, get_mcp_client, safe_tools
+from agent.tools import filter_tools, fix_dangling_tool_calls, get_mcp_client, make_messages_modifier, safe_tools
 
 if TYPE_CHECKING:
     from agent.agent import BugReproductionState
@@ -164,6 +164,7 @@ async def research_node(state: "BugReproductionState", llm: Any = None, client: 
         tools=stage_tools + [submit_tool],
         prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_RESEARCH_PROMPT}"),
         checkpointer=_saver,
+        pre_model_hook=make_messages_modifier(),
     )
 
     tool_call_count = 0
@@ -172,22 +173,26 @@ async def research_node(state: "BugReproductionState", llm: Any = None, client: 
         version="v2",
         config=_stage_config,
     ):
-        if event["event"] == "on_tool_start":
+        event_type = event["event"]
+        if event_type == "on_tool_start":
             tool_call_count += 1
             tool_name = event["name"]
             print(f"  [{tool_call_count}/{BUDGET}] {tool_name}", flush=True)
             if tool_name != "submit_research" and tool_call_count >= BUDGET:
                 break
+        elif event_type == "on_tool_end" and event.get("name") == "submit_research":
+            break
 
     base_count = state.get("tool_calls_used", 0)
     if not results:
         print(f"  [research] budget hit without submit — forcing synthesis from {tool_call_count} calls", flush=True)
         agent_state = await agent.aget_state(_stage_config)
-        accumulated = agent_state.values.get("messages", [])
+        accumulated = fix_dangling_tool_calls(agent_state.values.get("messages", []))
         submit_agent = create_react_agent(
             model=llm,
             tools=[submit_tool],
             prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_RESEARCH_PROMPT}"),
+            pre_model_hook=make_messages_modifier(),
         )
         async for _ in submit_agent.astream_events(
             {"messages": accumulated + [HumanMessage(content=(
@@ -196,7 +201,7 @@ async def research_node(state: "BugReproductionState", llm: Any = None, client: 
                 "Use empty lists for sources you didn't reach."
             ))]},
             version="v2",
-            config={"recursion_limit": 5},
+            config={"recursion_limit": 10},
         ):
             pass
 

--- a/backend/agent/stages/bug_research.py
+++ b/backend/agent/stages/bug_research.py
@@ -23,15 +23,18 @@ if TYPE_CHECKING:
 BUDGET = 20
 
 
-async def research_node(state: "BugReproductionState", llm: Any = None) -> dict:
+async def research_node(state: "BugReproductionState", llm: Any = None, client: Any = None) -> dict:
     if llm is None:
         from agent.agent import _llm
         llm = _llm
 
-    print("[bug_research] starting MCP client...", flush=True)
-    client = get_mcp_client()
+    _own_client = client is None
+    if _own_client:
+        print("[bug_research] starting MCP client...", flush=True)
+        client = get_mcp_client()
     all_tools = await client.get_tools()
-    print(f"[bug_research] got {len(all_tools)} tools, filtering to bug_research stage...", flush=True)
+    if _own_client:
+        print(f"[bug_research] got {len(all_tools)} tools, filtering to bug_research stage...", flush=True)
     stage_tools = safe_tools(filter_tools(all_tools, "bug_research"))
 
     available_tool_names = {t.name for t in stage_tools}

--- a/backend/agent/stages/bug_research.py
+++ b/backend/agent/stages/bug_research.py
@@ -8,9 +8,11 @@ Budget: 20 tool calls.
 """
 
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.tools import StructuredTool
+from langgraph.checkpoint.memory import MemorySaver
 from langgraph.prebuilt import create_react_agent
 from pydantic import BaseModel, Field
 
@@ -142,17 +144,22 @@ async def research_node(state: "BugReproductionState", llm: Any = None, client: 
         context_clause,
     ]))
 
+    _saver = MemorySaver()
+    _thread = f"{state.get('session_id', 'anon')}-research-{uuid4().hex[:8]}"
+    _stage_config = {"configurable": {"thread_id": _thread}, "recursion_limit": 50}
+
     agent = create_react_agent(
         model=llm,
         tools=stage_tools + [submit_tool],
         prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_RESEARCH_PROMPT}"),
+        checkpointer=_saver,
     )
 
     tool_call_count = 0
     async for event in agent.astream_events(
         {"messages": [HumanMessage(content=human_content)]},
         version="v2",
-        config={"recursion_limit": 50},
+        config=_stage_config,
     ):
         if event["event"] == "on_tool_start":
             tool_call_count += 1
@@ -162,6 +169,26 @@ async def research_node(state: "BugReproductionState", llm: Any = None, client: 
                 break
 
     base_count = state.get("tool_calls_used", 0)
+    if not results:
+        print(f"  [research] budget hit without submit — forcing synthesis from {tool_call_count} calls", flush=True)
+        agent_state = await agent.aget_state(_stage_config)
+        accumulated = agent_state.values.get("messages", [])
+        submit_agent = create_react_agent(
+            model=llm,
+            tools=[submit_tool],
+            prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_RESEARCH_PROMPT}"),
+        )
+        async for _ in submit_agent.astream_events(
+            {"messages": accumulated + [HumanMessage(content=(
+                f"[BUDGET EXHAUSTED after {tool_call_count} tool calls] "
+                "Call submit_research NOW with all findings gathered so far. "
+                "Use empty lists for sources you didn't reach."
+            ))]},
+            version="v2",
+            config={"recursion_limit": 5},
+        ):
+            pass
+
     if not results:
         return {
             "current_stage": "report_generation",

--- a/backend/agent/stages/bug_research.py
+++ b/backend/agent/stages/bug_research.py
@@ -102,12 +102,20 @@ async def research_node(state: "BugReproductionState", llm: Any = None, client: 
     affected_components = mechanics.get("affected_components", [])
 
     repo_name = state.get("repo_name")
-    repo_clause = (
-        f'Repo "{repo_name}" is indexed in GitNexus. '
-        f"Use `query` and `cypher` to find processes and symbols in the affected area."
-        if repo_name
-        else "No indexed repo — skip GitNexus tools."
-    )
+    # If mechanics already queried the code graph, steer research toward external sources only
+    if mechanics.get("code_paths"):
+        code_graph_clause = (
+            "Code graph was already queried extensively during mechanics analysis. "
+            "Do NOT use cypher or query tools — focus exclusively on external sources "
+            "(Jira, logs, documentation, network traces)."
+        )
+    elif repo_name:
+        code_graph_clause = (
+            f'Repo "{repo_name}" is indexed in GitNexus. '
+            "Use `query` and `cypher` to find processes and symbols in the affected area."
+        )
+    else:
+        code_graph_clause = "No indexed repo — skip GitNexus tools."
 
     attachments = state.get("attachments", [])
     attachment_clause = (
@@ -124,10 +132,13 @@ async def research_node(state: "BugReproductionState", llm: Any = None, client: 
     )
 
     available_sources = _available_sources(available_tool_names)
+    # Exclude code graph from listed sources if mechanics already covered it
+    if mechanics.get("code_paths") and "code graph" in available_sources:
+        available_sources = [s for s in available_sources if s != "code graph"]
     sources_clause = (
         f"Available sources for this run: {', '.join(available_sources)}"
         if available_sources
-        else "No external sources are configured — use code graph only."
+        else "No external sources are configured — call submit_research immediately with empty lists."
     )
 
     human_content = "\n".join(filter(None, [
@@ -138,7 +149,7 @@ async def research_node(state: "BugReproductionState", llm: Any = None, client: 
         f"Keywords: {', '.join(keywords) if keywords else 'none'}",
         f"Affected components: {', '.join(affected_components) if affected_components else 'none'}",
         f"Top hypothesis: {top_hypothesis}" if top_hypothesis else "",
-        repo_clause,
+        code_graph_clause,
         attachment_clause,
         sources_clause,
         context_clause,

--- a/backend/agent/stages/bug_triage.py
+++ b/backend/agent/stages/bug_triage.py
@@ -7,9 +7,11 @@ Budget: 8 tool calls.
 """
 
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.tools import StructuredTool
+from langgraph.checkpoint.memory import MemorySaver
 from langgraph.prebuilt import create_react_agent
 from pydantic import BaseModel, Field
 
@@ -106,17 +108,22 @@ async def triage_node(state: "BugReproductionState", llm: Any = None, client: An
         repo_clause,
     ]))
 
+    _saver = MemorySaver()
+    _thread = f"{state.get('session_id', 'anon')}-triage-{uuid4().hex[:8]}"
+    _stage_config = {"configurable": {"thread_id": _thread}, "recursion_limit": 30}
+
     agent = create_react_agent(
         model=llm,
         tools=stage_tools + [submit_tool],
         prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_TRIAGE_PROMPT}"),
+        checkpointer=_saver,
     )
 
     tool_call_count = 0
     async for event in agent.astream_events(
         {"messages": [HumanMessage(content=human_content)]},
         version="v2",
-        config={"recursion_limit": 30},
+        config=_stage_config,
     ):
         if event["event"] == "on_tool_start":
             tool_call_count += 1
@@ -125,6 +132,26 @@ async def triage_node(state: "BugReproductionState", llm: Any = None, client: An
                 break
 
     base_count = state.get("tool_calls_used", 0)
+    if not results:
+        print(f"  [triage] budget hit without submit — forcing synthesis from {tool_call_count} calls", flush=True)
+        agent_state = await agent.aget_state(_stage_config)
+        accumulated = agent_state.values.get("messages", [])
+        submit_agent = create_react_agent(
+            model=llm,
+            tools=[submit_tool],
+            prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_TRIAGE_PROMPT}"),
+        )
+        async for _ in submit_agent.astream_events(
+            {"messages": accumulated + [HumanMessage(content=(
+                f"[BUDGET EXHAUSTED after {tool_call_count} tool calls] "
+                "Call submit_triage NOW with your findings. No more research tools available. "
+                "Use confidence='low' if analysis is incomplete."
+            ))]},
+            version="v2",
+            config={"recursion_limit": 5},
+        ):
+            pass
+
     if not results:
         return {
             "current_stage": "mechanics_analysis",

--- a/backend/agent/stages/bug_triage.py
+++ b/backend/agent/stages/bug_triage.py
@@ -22,15 +22,18 @@ if TYPE_CHECKING:
 BUDGET = 8
 
 
-async def triage_node(state: "BugReproductionState", llm: Any = None) -> dict:
+async def triage_node(state: "BugReproductionState", llm: Any = None, client: Any = None) -> dict:
     if llm is None:
         from agent.agent import _llm
         llm = _llm
 
-    print("[bug_triage] starting MCP client...", flush=True)
-    client = get_mcp_client()
+    _own_client = client is None
+    if _own_client:
+        print("[bug_triage] starting MCP client...", flush=True)
+        client = get_mcp_client()
     all_tools = await client.get_tools()
-    print(f"[bug_triage] got {len(all_tools)} tools, filtering to bug_triage stage...", flush=True)
+    if _own_client:
+        print(f"[bug_triage] got {len(all_tools)} tools, filtering to bug_triage stage...", flush=True)
     stage_tools = safe_tools(filter_tools(all_tools, "bug_triage"))
 
     class _TriageOutput(BaseModel):

--- a/backend/agent/stages/bug_triage.py
+++ b/backend/agent/stages/bug_triage.py
@@ -16,7 +16,7 @@ from langgraph.prebuilt import create_react_agent
 from pydantic import BaseModel, Field
 
 from agent.prompts import BUG_BASE_PROMPT, BUG_TRIAGE_PROMPT
-from agent.tools import filter_tools, get_mcp_client, safe_tools
+from agent.tools import filter_tools, fix_dangling_tool_calls, get_mcp_client, make_messages_modifier, safe_tools
 
 if TYPE_CHECKING:
     from agent.agent import BugReproductionState
@@ -117,6 +117,7 @@ async def triage_node(state: "BugReproductionState", llm: Any = None, client: An
         tools=stage_tools + [submit_tool],
         prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_TRIAGE_PROMPT}"),
         checkpointer=_saver,
+        pre_model_hook=make_messages_modifier(),
     )
 
     tool_call_count = 0
@@ -125,21 +126,25 @@ async def triage_node(state: "BugReproductionState", llm: Any = None, client: An
         version="v2",
         config=_stage_config,
     ):
-        if event["event"] == "on_tool_start":
+        event_type = event["event"]
+        if event_type == "on_tool_start":
             tool_call_count += 1
             print(f"  [{tool_call_count}/{BUDGET}] {event['name']}", flush=True)
             if event["name"] != "submit_triage" and tool_call_count >= BUDGET:
                 break
+        elif event_type == "on_tool_end" and event.get("name") == "submit_triage":
+            break
 
     base_count = state.get("tool_calls_used", 0)
     if not results:
         print(f"  [triage] budget hit without submit — forcing synthesis from {tool_call_count} calls", flush=True)
         agent_state = await agent.aget_state(_stage_config)
-        accumulated = agent_state.values.get("messages", [])
+        accumulated = fix_dangling_tool_calls(agent_state.values.get("messages", []))
         submit_agent = create_react_agent(
             model=llm,
             tools=[submit_tool],
             prompt=SystemMessage(content=f"{BUG_BASE_PROMPT}\n\n{BUG_TRIAGE_PROMPT}"),
+            pre_model_hook=make_messages_modifier(),
         )
         async for _ in submit_agent.astream_events(
             {"messages": accumulated + [HumanMessage(content=(
@@ -148,7 +153,7 @@ async def triage_node(state: "BugReproductionState", llm: Any = None, client: An
                 "Use confidence='low' if analysis is incomplete."
             ))]},
             version="v2",
-            config={"recursion_limit": 5},
+            config={"recursion_limit": 10},
         ):
             pass
 

--- a/backend/agent/stages/e2e.py
+++ b/backend/agent/stages/e2e.py
@@ -107,11 +107,14 @@ async def run_e2e(state: "AnalysisState", llm: Any) -> dict:
         version="v2",
         config=_stage_config,
     ):
-        if event["event"] == "on_tool_start":
+        event_type = event["event"]
+        if event_type == "on_tool_start":
             tool_call_count += 1
             print(f"  [e2e {tool_call_count}/{BUDGET}] {event['name']}", flush=True)
             if event["name"] != "submit_e2e_plans" and tool_call_count >= BUDGET:
                 break
+        elif event_type == "on_tool_end" and event.get("name") == "submit_e2e_plans":
+            break
 
     if not e2e_results:
         print(f"  [e2e] budget hit without submit — forcing synthesis from {tool_call_count} calls", flush=True)

--- a/backend/agent/stages/e2e.py
+++ b/backend/agent/stages/e2e.py
@@ -11,9 +11,11 @@ Budget: 20 tool calls.
 """
 
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.tools import StructuredTool
+from langgraph.checkpoint.memory import MemorySaver
 from langgraph.prebuilt import create_react_agent
 
 from agent.prompts import BASE_PROMPT, E2E_PROMPT
@@ -78,31 +80,58 @@ async def run_e2e(state: "AnalysisState", llm: Any) -> dict:
     affected_files = [f for c in components for f in c.get("files_changed", [])]
     files_clause = f"Changed files: {', '.join(affected_files[:20])}" if affected_files else ""
 
+    _saver = MemorySaver()
+    _thread = f"{state.get('session_id', state.get('pr_url', 'anon'))}-e2e-{uuid4().hex[:8]}"
+    _stage_config = {"configurable": {"thread_id": _thread}, "recursion_limit": 50}
+
+    human_message = HumanMessage(content=(
+        f"{processes_clause}\n"
+        f"{files_clause}\n"
+        f"{repo_clause}"
+        f"{context_clause}\n\n"
+        "Identify which processes are affected by these file changes, "
+        "fetch their details, and generate E2E test plans. "
+        "Call submit_e2e_plans with all plans when done."
+    ))
+
     agent = create_react_agent(
         model=llm,
         tools=stage_tools + [submit_tool],
         prompt=SystemMessage(content=f"{BASE_PROMPT}\n\n{E2E_PROMPT}"),
+        checkpointer=_saver,
     )
 
     tool_call_count = 0
     async for event in agent.astream_events(
-        {"messages": [HumanMessage(content=(
-            f"{processes_clause}\n"
-            f"{files_clause}\n"
-            f"{repo_clause}"
-            f"{context_clause}\n\n"
-            "Identify which processes are affected by these file changes, "
-            "fetch their details, and generate E2E test plans. "
-            "Call submit_e2e_plans with all plans when done."
-        ))]},
+        {"messages": [human_message]},
         version="v2",
-        config={"recursion_limit": 50},
+        config=_stage_config,
     ):
         if event["event"] == "on_tool_start":
             tool_call_count += 1
             print(f"  [e2e {tool_call_count}/{BUDGET}] {event['name']}", flush=True)
             if event["name"] != "submit_e2e_plans" and tool_call_count >= BUDGET:
                 break
+
+    if not e2e_results:
+        print(f"  [e2e] budget hit without submit — forcing synthesis from {tool_call_count} calls", flush=True)
+        agent_state = await agent.aget_state(_stage_config)
+        accumulated = agent_state.values.get("messages", [])
+        submit_agent = create_react_agent(
+            model=llm,
+            tools=[submit_tool],
+            prompt=SystemMessage(content=f"{BASE_PROMPT}\n\n{E2E_PROMPT}"),
+        )
+        async for _ in submit_agent.astream_events(
+            {"messages": accumulated + [HumanMessage(content=(
+                f"[BUDGET EXHAUSTED after {tool_call_count} tool calls] "
+                "Call submit_e2e_plans NOW with all E2E test plans from your analysis. "
+                "Use priority='LOW' for any plans with incomplete process details."
+            ))]},
+            version="v2",
+            config={"recursion_limit": 5},
+        ):
+            pass
 
     return {
         "tool_calls_used": state.get("tool_calls_used", 0) + tool_call_count,

--- a/backend/agent/stages/gather.py
+++ b/backend/agent/stages/gather.py
@@ -97,11 +97,14 @@ async def run_gather(state: "AnalysisState", llm: Any) -> dict:
         version="v2",
         config=_stage_config,
     ):
-        if event["event"] == "on_tool_start":
+        event_type = event["event"]
+        if event_type == "on_tool_start":
             tool_call_count += 1
             print(f"  [{tool_call_count}/{BUDGET}] {event['name']}", flush=True)
             if event["name"] != "submit_gather" and tool_call_count >= BUDGET:
                 break
+        elif event_type == "on_tool_end" and event.get("name") == "submit_gather":
+            break
 
     base_count = state.get("tool_calls_used", 0)
     if not results:

--- a/backend/agent/stages/gather.py
+++ b/backend/agent/stages/gather.py
@@ -6,9 +6,11 @@ Budget: 10 tool calls. Does not generate test specs — collect only.
 """
 
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.tools import StructuredTool
+from langgraph.checkpoint.memory import MemorySaver
 from langgraph.prebuilt import create_react_agent
 from pydantic import BaseModel, Field
 
@@ -78,17 +80,22 @@ async def run_gather(state: "AnalysisState", llm: Any) -> dict:
         else "No indexed repo — use GitHub tools only."
     )
 
+    _saver = MemorySaver()
+    _thread = f"{state.get('session_id', state.get('pr_url', 'anon'))}-gather-{uuid4().hex[:8]}"
+    _stage_config = {"configurable": {"thread_id": _thread}, "recursion_limit": 30}
+
     agent = create_react_agent(
         model=llm,
         tools=stage_tools + [submit_tool],
         prompt=SystemMessage(content=f"{BASE_PROMPT}\n\n{GATHER_PROMPT}"),
+        checkpointer=_saver,
     )
 
     tool_call_count = 0
     async for event in agent.astream_events(
         {"messages": [HumanMessage(content=f"Gather context for: {state['pr_url']}\n{repo_clause}")]},
         version="v2",
-        config={"recursion_limit": 30},
+        config=_stage_config,
     ):
         if event["event"] == "on_tool_start":
             tool_call_count += 1
@@ -97,6 +104,26 @@ async def run_gather(state: "AnalysisState", llm: Any) -> dict:
                 break
 
     base_count = state.get("tool_calls_used", 0)
+    if not results:
+        print(f"  [gather] budget hit without submit — forcing synthesis from {tool_call_count} calls", flush=True)
+        agent_state = await agent.aget_state(_stage_config)
+        accumulated = agent_state.values.get("messages", [])
+        submit_agent = create_react_agent(
+            model=llm,
+            tools=[submit_tool],
+            prompt=SystemMessage(content=f"{BASE_PROMPT}\n\n{GATHER_PROMPT}"),
+        )
+        async for _ in submit_agent.astream_events(
+            {"messages": accumulated + [HumanMessage(content=(
+                f"[BUDGET EXHAUSTED after {tool_call_count} tool calls] "
+                "Call submit_gather NOW with all context collected so far. "
+                "Use confidence='low' for any components not fully analysed."
+            ))]},
+            version="v2",
+            config={"recursion_limit": 5},
+        ):
+            pass
+
     if not results:
         return {"current_stage": "unit_tests", "tool_calls_used": base_count + tool_call_count}
 

--- a/backend/agent/stages/integration.py
+++ b/backend/agent/stages/integration.py
@@ -100,11 +100,14 @@ async def run_integration(state: "AnalysisState", llm: Any) -> dict:
         version="v2",
         config=_stage_config,
     ):
-        if event["event"] == "on_tool_start":
+        event_type = event["event"]
+        if event_type == "on_tool_start":
             tool_call_count += 1
             print(f"  [integration {tool_call_count}/{BUDGET}] {event['name']}", flush=True)
             if event["name"] != "submit_integration_tests" and tool_call_count >= BUDGET:
                 break
+        elif event_type == "on_tool_end" and event.get("name") == "submit_integration_tests":
+            break
 
     if not integration_results:
         print(f"  [integration] budget hit without submit — forcing synthesis from {tool_call_count} calls", flush=True)

--- a/backend/agent/stages/integration.py
+++ b/backend/agent/stages/integration.py
@@ -11,9 +11,11 @@ Budget: 15 tool calls.
 """
 
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.tools import StructuredTool
+from langgraph.checkpoint.memory import MemorySaver
 from langgraph.prebuilt import create_react_agent
 
 from agent.prompts import BASE_PROMPT, INTEGRATION_PROMPT
@@ -73,29 +75,56 @@ async def run_integration(state: "AnalysisState", llm: Any) -> dict:
         else ""
     )
 
+    _saver = MemorySaver()
+    _thread = f"{state.get('session_id', state.get('pr_url', 'anon'))}-integration-{uuid4().hex[:8]}"
+    _stage_config = {"configurable": {"thread_id": _thread}, "recursion_limit": 40}
+
+    human_message = HumanMessage(content=(
+        f"{diff_section}"
+        f"Affected components:\n{components_block}\n\n"
+        f"{repo_clause}\n\n"
+        "Use impact/context/query/cypher to find cross-module integration points. "
+        "When done, call submit_integration_tests with all specs at once."
+    ))
+
     agent = create_react_agent(
         model=llm,
         tools=stage_tools + [submit_tool],
         prompt=SystemMessage(content=f"{BASE_PROMPT}\n\n{INTEGRATION_PROMPT}"),
+        checkpointer=_saver,
     )
 
     tool_call_count = 0
     async for event in agent.astream_events(
-        {"messages": [HumanMessage(content=(
-            f"{diff_section}"
-            f"Affected components:\n{components_block}\n\n"
-            f"{repo_clause}\n\n"
-            "Use impact/context/query/cypher to find cross-module integration points. "
-            "When done, call submit_integration_tests with all specs at once."
-        ))]},
+        {"messages": [human_message]},
         version="v2",
-        config={"recursion_limit": 40},
+        config=_stage_config,
     ):
         if event["event"] == "on_tool_start":
             tool_call_count += 1
             print(f"  [integration {tool_call_count}/{BUDGET}] {event['name']}", flush=True)
             if event["name"] != "submit_integration_tests" and tool_call_count >= BUDGET:
                 break
+
+    if not integration_results:
+        print(f"  [integration] budget hit without submit — forcing synthesis from {tool_call_count} calls", flush=True)
+        agent_state = await agent.aget_state(_stage_config)
+        accumulated = agent_state.values.get("messages", [])
+        submit_agent = create_react_agent(
+            model=llm,
+            tools=[submit_tool],
+            prompt=SystemMessage(content=f"{BASE_PROMPT}\n\n{INTEGRATION_PROMPT}"),
+        )
+        async for _ in submit_agent.astream_events(
+            {"messages": accumulated + [HumanMessage(content=(
+                f"[BUDGET EXHAUSTED after {tool_call_count} tool calls] "
+                "Call submit_integration_tests NOW with all integration points found. "
+                "Use risk_level='LOW' for any specs with incomplete evidence."
+            ))]},
+            version="v2",
+            config={"recursion_limit": 5},
+        ):
+            pass
 
     # Distribute integration specs back into affected_components by module name matching
     updated = []

--- a/backend/agent/stages/unit.py
+++ b/backend/agent/stages/unit.py
@@ -9,9 +9,11 @@ Budget: 15 tool calls total across all components.
 """
 
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 from langchain_core.messages import HumanMessage, SystemMessage
 from langchain_core.tools import StructuredTool
+from langgraph.checkpoint.memory import MemorySaver
 from langgraph.prebuilt import create_react_agent
 
 from agent.prompts import BASE_PROMPT, UNIT_PROMPT
@@ -77,10 +79,28 @@ async def run_unit(state: "AnalysisState", llm: Any) -> dict:
         else ""
     )
 
+    _saver = MemorySaver()
+    _thread = f"{state.get('session_id', state.get('pr_url', 'anon'))}-unit-{uuid4().hex[:8]}"
+    _stage_config = {"configurable": {"thread_id": _thread}, "recursion_limit": 60}
+
+    human_message = HumanMessage(content=(
+        f"{diff_section}"
+        f"{feedback_section}\n\n"
+        f"Process these components ONE AT A TIME in order:\n\n{components_block}\n\n"
+        f"{repo_clause}\n\n"
+        "For each component:\n"
+        "1. Use the diff above — do NOT call get_file_contents\n"
+        "2. Use context/cypher only if you need deeper graph info\n"
+        "3. Call submit_unit_tests with the specs\n"
+        "4. Only then move to the next component\n\n"
+        f"Total budget: {BUDGET} tool calls."
+    ))
+
     agent = create_react_agent(
         model=llm,
         tools=stage_tools + [submit_tool],
         prompt=SystemMessage(content=f"{BASE_PROMPT}\n\n{UNIT_PROMPT}"),
+        checkpointer=_saver,
     )
 
     tool_call_count = 0
@@ -88,20 +108,9 @@ async def run_unit(state: "AnalysisState", llm: Any) -> dict:
     expected_submits = len(components)
 
     async for event in agent.astream_events(
-        {"messages": [HumanMessage(content=(
-            f"{diff_section}"
-            f"{feedback_section}\n\n"
-            f"Process these components ONE AT A TIME in order:\n\n{components_block}\n\n"
-            f"{repo_clause}\n\n"
-            "For each component:\n"
-            "1. Use the diff above — do NOT call get_file_contents\n"
-            "2. Use context/cypher only if you need deeper graph info\n"
-            "3. Call submit_unit_tests with the specs\n"
-            "4. Only then move to the next component\n\n"
-            f"Total budget: {BUDGET} tool calls."
-        ))]},
+        {"messages": [human_message]},
         version="v2",
-        config={"recursion_limit": 60},
+        config=_stage_config,
     ):
         if event["event"] == "on_tool_start":
             tool_call_count += 1
@@ -109,9 +118,31 @@ async def run_unit(state: "AnalysisState", llm: Any) -> dict:
             if event["name"] == "submit_unit_tests":
                 submit_count += 1
                 if submit_count >= expected_submits:
-                    break  # All components submitted — don't wait for agent's final text
+                    break  # All components submitted
             elif tool_call_count >= BUDGET:
                 break
+
+    # If budget hit before any component was submitted, force a submit pass
+    if not unit_results:
+        print(f"  [unit] budget hit without any submit — forcing synthesis from {tool_call_count} calls", flush=True)
+        agent_state = await agent.aget_state(_stage_config)
+        accumulated = agent_state.values.get("messages", [])
+        pending = "\n".join(f"- {c.get('component')}" for c in components)
+        submit_agent = create_react_agent(
+            model=llm,
+            tools=[submit_tool],
+            prompt=SystemMessage(content=f"{BASE_PROMPT}\n\n{UNIT_PROMPT}"),
+        )
+        async for _ in submit_agent.astream_events(
+            {"messages": accumulated + [HumanMessage(content=(
+                f"[BUDGET EXHAUSTED after {tool_call_count} tool calls] "
+                f"Call submit_unit_tests for each of these components with your best analysis:\n{pending}\n"
+                "Use the diff context already in this conversation. Prioritise high-risk components."
+            ))]},
+            version="v2",
+            config={"recursion_limit": 20},
+        ):
+            pass
 
     updated = [
         {**c, "unit_tests": unit_results.get(c.get("component", ""), [])}

--- a/backend/agent/tools.py
+++ b/backend/agent/tools.py
@@ -61,9 +61,9 @@ BUG_MECHANICS_TOOLS: set[str] = {
     "get_file_contents",
     "search_code",
     "cypher",
+    "query",
     "context",
     "impact",
-    "detect_changes",
     "list_directory",
 }
 
@@ -79,6 +79,7 @@ BUG_REPRODUCTION_TOOLS: set[str] = {
 
 BUG_RESEARCH_TOOLS: set[str] = {
     "cypher",
+    "query",
     "jira_search",
     "jira_get_issue",
     "jira_get_comments",

--- a/backend/agent/tools.py
+++ b/backend/agent/tools.py
@@ -51,7 +51,6 @@ BUG_TRIAGE_TOOLS: set[str] = {
     "jira_get_issue",
     "jira_get_comments",
     "search_code",
-    "get_file_contents",
     "cypher",
     "impact",
     "list_repos",
@@ -180,6 +179,88 @@ def safe_tools(tools: list) -> list:
 
         wrapped.append(tool.copy(update={"coroutine": _safe, "func": None}))
     return wrapped
+
+
+_TOOL_OUTPUT_MAX_CHARS = 12_000  # ~3k tokens per tool result
+
+# Keep the old name as an alias so existing call sites don't break
+_FILE_TOOL_MAX_CHARS = _TOOL_OUTPUT_MAX_CHARS
+
+
+def make_messages_modifier(max_chars: int = _TOOL_OUTPUT_MAX_CHARS):
+    """
+    Return a pre_model_hook for create_react_agent that caps every ToolMessage
+    content at max_chars before it reaches the LLM.
+
+    This runs inside the agent executor right before each LLM call, so it prevents
+    large tool outputs from bloating the context window across the entire stage.
+    Handles both plain-string and list-of-blocks ToolMessage formats.
+
+    Usage: create_react_agent(..., pre_model_hook=make_messages_modifier())
+    """
+    from langchain_core.messages import ToolMessage
+
+    def _hook(state: dict) -> dict:
+        messages = state.get("messages", [])
+        updated = []
+        any_changed = False
+        for msg in messages:
+            if not isinstance(msg, ToolMessage):
+                updated.append(msg)
+                continue
+            content = msg.content
+            if isinstance(content, str) and len(content) > max_chars:
+                content = content[:max_chars] + f"\n...[output truncated — {len(content) - max_chars} chars omitted]"
+                msg = msg.copy(update={"content": content})
+                any_changed = True
+            elif isinstance(content, list):
+                new_blocks = []
+                changed = False
+                for block in content:
+                    if isinstance(block, dict) and block.get("type") == "text":
+                        text = block.get("text", "")
+                        if len(text) > max_chars:
+                            block = {**block, "text": text[:max_chars] + f"\n...[output truncated — {len(text) - max_chars} chars omitted]"}
+                            changed = True
+                    new_blocks.append(block)
+                if changed:
+                    msg = msg.copy(update={"content": new_blocks})
+                    any_changed = True
+            updated.append(msg)
+        return {"messages": updated} if any_changed else {}
+
+    return _hook
+
+
+def fix_dangling_tool_calls(messages: list) -> list:
+    """
+    After a budget break the last AIMessage may contain tool_calls that never
+    executed (common when the agent issues parallel tool calls and we break
+    mid-stream).  Without matching ToolMessages the chat history is invalid and
+    most LLM providers reject it.
+
+    Appends a synthetic ToolMessage for every unmatched tool_call_id so the
+    history is well-formed before passing it to the forced-submit agent.
+    """
+    from langchain_core.messages import AIMessage, ToolMessage
+
+    tool_message_ids = {msg.tool_call_id for msg in messages if isinstance(msg, ToolMessage)}
+    fixed = []
+    for msg in messages:
+        fixed.append(msg)
+        if isinstance(msg, AIMessage) and msg.tool_calls:
+            for tc in msg.tool_calls:
+                if tc["id"] not in tool_message_ids:
+                    fixed.append(ToolMessage(
+                        content="[Interrupted: budget limit reached before this tool call completed]",
+                        tool_call_id=tc["id"],
+                    ))
+    return fixed
+
+
+def truncate_large_tools(tools: list, max_chars: int = _TOOL_OUTPUT_MAX_CHARS) -> list:
+    """Kept for backwards compatibility — prefer make_messages_modifier instead."""
+    return tools
 
 
 def filter_tools(all_tools: list, stage: str) -> list:

--- a/backend/evals/bug_evaluators.py
+++ b/backend/evals/bug_evaluators.py
@@ -173,4 +173,268 @@ def reproduction_executability(outputs: dict) -> dict:
     return {"key": "reproduction_executability", "score": score, "comment": comment, "details": details}
 
 
-# --- Person 2 evaluators below ---
+# ═══════════════════════════════════════════════════════════════════════════════
+# Person 2 evaluators — stages 4-5 + pipeline-level
+# ═══════════════════════════════════════════════════════════════════════════════
+
+_TOTAL_BUDGET = 60  # 8 + 15 + 12 + 20 + 5
+_VALID_CONFIDENCES = {"high", "medium", "low"}
+_MIN_RECOMMENDATION_LENGTH = 30  # chars — filters out "fix the bug" style non-answers
+
+
+def bug_pipeline_health(outputs: dict) -> dict:
+    """
+    Checks that every stage produced a non-empty output dict.
+    Score = fraction of stages that completed (5 stages total).
+    """
+    stages = {
+        "triage": outputs.get("triage", {}),
+        "mechanics": outputs.get("mechanics", {}),
+        "reproduction_plan": outputs.get("reproduction_plan", {}),
+        "research_findings": outputs.get("research_findings", {}),
+        "bug_report": outputs.get("bug_report", {}),
+    }
+
+    details = [
+        {
+            "check": f"{stage} output non-empty",
+            "passed": bool(data),
+            "value": "present" if data else "missing",
+        }
+        for stage, data in stages.items()
+    ]
+
+    passed = [d for d in details if d["passed"]]
+    failed = [d for d in details if not d["passed"]]
+    score = len(passed) / len(details)
+    comment = "all stages completed" if not failed else f"missing: {', '.join(d['check'].split()[0] for d in failed)}"
+    return {"key": "bug_pipeline_health", "score": score, "comment": comment, "details": details}
+
+
+def research_coverage(outputs: dict) -> dict:
+    """
+    Checks how many sources returned useful data out of those queried.
+    Score = sources_with_results / sources_queried.
+    Zero sources queried scores 0.0 (research did not run).
+    """
+    findings = outputs.get("research_findings", {})
+    if not findings:
+        return {"key": "research_coverage", "score": 0.0, "comment": "research_findings missing", "details": []}
+
+    queried = findings.get("sources_queried", [])
+    with_results = findings.get("sources_with_results", [])
+
+    details = [
+        {
+            "check": "at least one source queried",
+            "passed": len(queried) >= 1,
+            "value": f"{len(queried)} queried: {queried}",
+        },
+        {
+            "check": "at least one source returned results",
+            "passed": len(with_results) >= 1,
+            "value": f"{len(with_results)} with results: {with_results}",
+        },
+    ]
+
+    if not queried:
+        score = 0.0
+    else:
+        score = len(with_results) / len(queried)
+
+    failed = [d for d in details if not d["passed"]]
+    comment = (
+        f"{len(with_results)}/{len(queried)} sources returned data"
+        if queried
+        else "no sources were queried"
+    )
+    return {"key": "research_coverage", "score": score, "comment": comment, "details": details}
+
+
+def report_completeness(outputs: dict) -> dict:
+    """
+    Checks that every required field in bug_report is non-empty.
+    Score = fraction of required fields present.
+    """
+    report = outputs.get("bug_report", {})
+    if not report:
+        return {"key": "report_completeness", "score": 0.0, "comment": "bug_report missing", "details": []}
+
+    required_fields = [
+        ("title", lambda v: bool(v)),
+        ("severity", lambda v: v in _VALID_SEVERITIES),
+        ("root_cause", lambda v: bool(v)),
+        ("reproduction_steps", lambda v: len(v) >= 3),
+        ("affected_components", lambda v: len(v) >= 1),
+        ("recommendations", lambda v: len(v) >= 1),
+        ("confidence", lambda v: v in _VALID_CONFIDENCES),
+    ]
+
+    details = []
+    for field, check in required_fields:
+        value = report.get(field)
+        passed = check(value) if value is not None else False
+        display = str(value)[:80] if value else "(missing)"
+        details.append({
+            "check": f"{field} valid",
+            "passed": passed,
+            "value": display,
+        })
+
+    passed_count = sum(1 for d in details if d["passed"])
+    score = passed_count / len(details)
+    failed = [d for d in details if not d["passed"]]
+    comment = "all fields present" if not failed else f"failed: {', '.join(d['check'] for d in failed)}"
+    return {"key": "report_completeness", "score": score, "comment": comment, "details": details}
+
+
+def report_actionability(outputs: dict) -> dict:
+    """
+    Checks that recommendations are specific and actionable (not generic).
+    Score = fraction of recommendations exceeding minimum length threshold.
+    Requires at least 2 recommendations.
+    """
+    report = outputs.get("bug_report", {})
+    if not report:
+        return {"key": "report_actionability", "score": 0.0, "comment": "bug_report missing", "details": []}
+
+    recommendations = report.get("recommendations", [])
+
+    details = [
+        {
+            "check": "recommendations >= 2",
+            "passed": len(recommendations) >= 2,
+            "value": f"{len(recommendations)} recommendation(s)",
+        }
+    ]
+
+    for i, rec in enumerate(recommendations):
+        rec_str = str(rec).strip()
+        passed = len(rec_str) >= _MIN_RECOMMENDATION_LENGTH
+        details.append({
+            "check": f"recommendation[{i}] sufficiently specific (>= {_MIN_RECOMMENDATION_LENGTH} chars)",
+            "passed": passed,
+            "value": (rec_str[:80] + "…") if len(rec_str) > 80 else rec_str,
+        })
+
+    if len(recommendations) < 2:
+        score = 0.0
+    else:
+        actionable = sum(1 for r in recommendations if len(str(r).strip()) >= _MIN_RECOMMENDATION_LENGTH)
+        score = actionable / len(recommendations)
+
+    failed = [d for d in details if not d["passed"]]
+    comment = "all recommendations actionable" if not failed else f"failed: {', '.join(d['check'] for d in failed)}"
+    return {"key": "report_actionability", "score": score, "comment": comment, "details": details}
+
+
+def evidence_quality(outputs: dict) -> dict:
+    """
+    Checks whether the bug report contains substantive evidence across categories.
+    Score = fraction of evidence categories that contain at least one entry.
+    """
+    report = outputs.get("bug_report", {})
+    if not report:
+        return {"key": "evidence_quality", "score": 0.0, "comment": "bug_report missing", "details": []}
+
+    evidence = report.get("evidence", {})
+    if not evidence:
+        return {"key": "evidence_quality", "score": 0.0, "comment": "evidence field missing from report", "details": []}
+
+    categories = ["log_entries", "doc_references", "related_issues", "network_traces"]
+
+    details = [
+        {
+            "check": f"{cat} non-empty",
+            "passed": len(evidence.get(cat, [])) >= 1,
+            "value": f"{len(evidence.get(cat, []))} item(s)",
+        }
+        for cat in categories
+    ]
+
+    filled = [d for d in details if d["passed"]]
+    score = len(filled) / len(details)
+
+    comment = (
+        f"{len(filled)}/{len(details)} evidence categories populated"
+        if filled
+        else "no evidence found in any category"
+    )
+    return {"key": "evidence_quality", "score": score, "comment": comment, "details": details}
+
+
+def tool_efficiency(outputs: dict) -> dict:
+    """
+    Checks whether the pipeline stayed within the combined tool call budget.
+    Combined budget: 8 + 15 + 12 + 20 + 5 = 60 calls.
+    Score = 1.0 if within budget, scales linearly to 0.0 at 2x budget (120 calls).
+    """
+    used = outputs.get("tool_calls_used", 0)
+
+    within_budget = used <= _TOTAL_BUDGET
+    details = [
+        {
+            "check": f"total tool calls <= {_TOTAL_BUDGET}",
+            "passed": within_budget,
+            "value": f"{used} calls used",
+        }
+    ]
+
+    if used <= _TOTAL_BUDGET:
+        score = 1.0
+    elif used >= _TOTAL_BUDGET * 2:
+        score = 0.0
+    else:
+        score = 1.0 - (used - _TOTAL_BUDGET) / _TOTAL_BUDGET
+
+    comment = (
+        f"within budget ({used}/{_TOTAL_BUDGET})"
+        if within_budget
+        else f"over budget ({used}/{_TOTAL_BUDGET})"
+    )
+    return {"key": "tool_efficiency", "score": round(score, 2), "comment": comment, "details": details}
+
+
+def graceful_degradation(outputs: dict) -> dict:
+    """
+    Checks that the pipeline produces a complete report even when external
+    sources return no data (zero tools configured or all sources empty).
+    Score = 1.0 if bug_report is non-empty regardless of research results.
+    """
+    report = outputs.get("bug_report", {})
+    findings = outputs.get("research_findings", {})
+
+    sources_with_results = findings.get("sources_with_results", [])
+    report_present = bool(report)
+    research_empty = len(sources_with_results) == 0
+
+    details = [
+        {
+            "check": "bug_report produced",
+            "passed": report_present,
+            "value": "present" if report_present else "missing",
+        },
+        {
+            "check": "report present even with no external evidence",
+            "passed": report_present and research_empty,
+            "value": (
+                "report generated with zero external sources"
+                if report_present and research_empty
+                else "research had results — degradation not tested"
+                if report_present
+                else "no report generated"
+            ),
+        },
+    ]
+
+    if not report_present:
+        score = 0.0
+        comment = "pipeline failed to produce a report"
+    elif research_empty:
+        score = 1.0
+        comment = "report produced with zero external evidence — graceful degradation confirmed"
+    else:
+        score = 0.5
+        comment = "report produced but external sources had results — degradation not fully tested"
+
+    return {"key": "graceful_degradation", "score": score, "comment": comment, "details": details}

--- a/backend/evals/bug_evaluators.py
+++ b/backend/evals/bug_evaluators.py
@@ -330,27 +330,36 @@ def report_actionability(outputs: dict) -> dict:
 
 def evidence_quality(outputs: dict) -> dict:
     """
-    Checks whether the bug report contains substantive evidence across categories.
-    Score = fraction of evidence categories that contain at least one entry.
+    Checks whether evidence was gathered across categories.
+    External categories (from bug_report.evidence): log_entries, doc_references,
+    related_issues, network_traces.
+    Internal category (from research_findings): code_graph_hits.
+    Score = fraction of all 5 categories that contain at least one entry.
     """
     report = outputs.get("bug_report", {})
     if not report:
         return {"key": "evidence_quality", "score": 0.0, "comment": "bug_report missing", "details": []}
 
     evidence = report.get("evidence", {})
-    if not evidence:
-        return {"key": "evidence_quality", "score": 0.0, "comment": "evidence field missing from report", "details": []}
+    research = outputs.get("research_findings", {})
 
-    categories = ["log_entries", "doc_references", "related_issues", "network_traces"]
-
+    external_categories = ["log_entries", "doc_references", "related_issues", "network_traces"]
     details = [
         {
             "check": f"{cat} non-empty",
             "passed": len(evidence.get(cat, [])) >= 1,
             "value": f"{len(evidence.get(cat, []))} item(s)",
         }
-        for cat in categories
+        for cat in external_categories
     ]
+
+    # Code graph hits live in research_findings, not bug_report.evidence
+    code_graph_hits = research.get("code_graph_hits", [])
+    details.append({
+        "check": "code_graph_hits non-empty",
+        "passed": len(code_graph_hits) >= 1,
+        "value": f"{len(code_graph_hits)} hit(s)",
+    })
 
     filled = [d for d in details if d["passed"]]
     score = len(filled) / len(details)

--- a/backend/evals/create_dataset.py
+++ b/backend/evals/create_dataset.py
@@ -293,6 +293,52 @@ GITHUB_ONLY_EXAMPLES = [
 ]
 
 
+# ── Dataset 3: Bug reproduction examples (Sprint 3) ──────────────────────────
+# Each example has a real bug description + ground truth root cause, affected
+# files, and components so evaluators can measure pipeline accuracy.
+
+BUG_EXAMPLES = [
+    # ── OpenTTD: UI crash — timetable widget layout assertion ─────────────────
+    {
+        "_category": "UI crash — widget layout assertion",
+        "inputs": {
+            "description": (
+                'After disabling "Show arrival and departure date on timetable" in '
+                "Settings → Interface → Timetable settings, opening any vehicle's "
+                'timetable window causes an immediate crash with assertion failure: '
+                '"cur_height < max_smallest" at widget.cpp line 1578 inside '
+                "NWidgetHorizontal::SetupSmallestSize(). Reproducible 100% on a "
+                "fresh game with no mods. Reverting the setting prevents the crash."
+            ),
+            "environment": "Windows 11, openttd-15.0-beta3",
+            "severity_input": "high",
+            "repo_name": "OpenTTD",
+        },
+        "outputs": {
+            "expected_root_cause_keywords": [
+                "fallthrough",
+                "UpdateWidgetSize",
+                "UpdateSelectionStates",
+                "FinishInitNested",
+                "SetDisplayedPlane",
+            ],
+            "expected_affected_files": [
+                "src/timetable_gui.cpp",
+                "src/widget.cpp",
+            ],
+            "expected_affected_components": [
+                "TimetableWindow",
+                "NWidgetHorizontal",
+                "UpdateSelectionStates",
+            ],
+            "expected_severity": "high",
+            "expected_category": "crash",
+            "min_reproduction_steps": 3,
+        },
+    },
+]
+
+
 if __name__ == "__main__":
     print("Creating LangSmith datasets...")
     _upsert_dataset(
@@ -304,5 +350,10 @@ if __name__ == "__main__":
         "qlankr-eval-github",
         "External repo PRs without indexing — tests GitHub-only fallback path",
         GITHUB_ONLY_EXAMPLES,
+    )
+    _upsert_dataset(
+        "qlankr-eval-bugs",
+        "Bug descriptions with ground truth root cause — tests Sprint 3 bug reproduction pipeline",
+        BUG_EXAMPLES,
     )
     print("Done.")

--- a/backend/tests/agent/fixtures/openttd_timetable_crash.json
+++ b/backend/tests/agent/fixtures/openttd_timetable_crash.json
@@ -1,0 +1,28 @@
+{
+  "id": "openttd_timetable_crash",
+  "description": "After disabling \"Show arrival and departure date on timetable\" in Settings → Interface → Timetable settings, opening any vehicle's timetable window causes an immediate crash with assertion failure: \"cur_height < max_smallest\" at widget.cpp line 1578 inside NWidgetHorizontal::SetupSmallestSize(). Reproducible 100% on a fresh game with no mods. Reverting the setting prevents the crash.",
+  "environment": "Windows 11, openttd-15.0-beta3",
+  "severity_input": "high",
+  "repo_name": "OpenTTD",
+  "jira_ticket": null,
+  "attachments": [],
+  "ground_truth": {
+    "root_cause": "Two cooperating bugs: (1) UpdateWidgetSize() uses [[fallthrough]] from WID_VT_ARRIVAL_DEPARTURE_PANEL into WID_VT_TIMETABLE_PANEL, unconditionally assigning an 8-row height to the arrival/departure panel regardless of its visibility. (2) The TimetableWindow constructor calls UpdateSelectionStates() — which hides the arrival/departure panel via SetDisplayedPlane(SZSP_NONE) — before FinishInitNested() runs. The hidden stacked container reports zero height while its child retains the pre-computed large height, violating the cur_height < max_smallest invariant in NWidgetHorizontal::SetupSmallestSize() at widget.cpp:1578.",
+    "affected_files": [
+      "src/timetable_gui.cpp",
+      "src/widgets/timetable_widget.h",
+      "src/widget.cpp"
+    ],
+    "affected_components": [
+      "TimetableWindow",
+      "UpdateSelectionStates",
+      "UpdateWidgetSize",
+      "NWidgetStacked",
+      "NWidgetHorizontal"
+    ],
+    "severity": "high",
+    "category": "crash",
+    "fix_hint": "Either remove the [[fallthrough]] in UpdateWidgetSize() and guard height assignment on setting value, or move the UpdateSelectionStates() call to after FinishInitNested() in the constructor.",
+    "reproduction_trigger": "Disable 'Show arrival and departure date on timetable' setting, then open any vehicle's timetable window"
+  }
+}

--- a/backend/tests/agent/test_bug_reproduction.py
+++ b/backend/tests/agent/test_bug_reproduction.py
@@ -1,8 +1,8 @@
 """
-Manual test for bug reproduction stages 1-3.
-Run from backend/: python -m tests.agent.test_bug_triage [stage]
+Manual test for bug reproduction stages 1-4.
+Run from backend/: python -m tests.agent.test_bug_reproduction [stage]
 
-Stages: triage (default), mechanics, reproduction, all
+Stages: triage (default), mechanics, reproduction, research, all
 """
 
 import asyncio
@@ -19,6 +19,7 @@ from agent.agent import BugReproductionState, _llm
 from agent.stages.bug_triage import triage_node
 from agent.stages.bug_mechanics import mechanics_node as mechanics_analysis_node
 from agent.stages.bug_reproduction import reproduction_node as reproduction_planning_node
+from agent.stages.bug_research import research_node
 from evals.bug_evaluators import mechanics_grounding, reproduction_executability, triage_accuracy
 
 # ── Sample bug description ────────────────────────────────────────────────────
@@ -56,6 +57,14 @@ initial_state: BugReproductionState = {
 }
 
 
+_STAGE_KEY = {
+    "triage": "triage",
+    "mechanics": "mechanics",
+    "reproduction": "reproduction_plan",
+    "research": "research_findings",
+}
+
+
 def _print_result(stage: str, result: dict) -> None:
     print(f"\n{'='*60}")
     print(f"=== {stage.upper()} RESULT ===")
@@ -63,7 +72,7 @@ def _print_result(stage: str, result: dict) -> None:
     print(f"  next stage      : {result.get('current_stage')}")
     print(f"  tool_calls_used : {result.get('tool_calls_used', 0)}")
 
-    key = {"triage": "triage", "mechanics": "mechanics", "reproduction": "reproduction_plan"}[stage]
+    key = _STAGE_KEY.get(stage, stage)
     data = result.get(key, {})
     if data:
         print(f"\n--- {key} ---")
@@ -168,6 +177,34 @@ async def run_all():
     _print_evals(combined)
 
 
+async def run_research_only(repro_result: dict | None = None):
+    state = {**initial_state}
+    if repro_result:
+        state = {**state, **repro_result}
+    if not state.get("triage"):
+        state["triage"] = {
+            "bug_category": "gameplay",
+            "keywords": ["fast travel", "equip", "inventory", "zone transition"],
+            "severity": "high",
+            "affected_area": "fast travel / inventory system",
+            "affected_files": [],
+            "initial_hypotheses": ["InventoryManager.reset() called during zone transition"],
+            "confidence": "medium",
+        }
+    if not state.get("mechanics"):
+        state["mechanics"] = {
+            "code_paths": [{"path": "FastTravel.execute→ZoneManager.transition→InventoryManager.reset", "description": "Equipment cleared on transition", "confidence": "medium"}],
+            "affected_components": ["FastTravelSystem", "InventoryManager", "ZoneManager"],
+            "root_cause_hypotheses": [
+                {"hypothesis": "InventoryManager.reset() drops equipped items during zone transition", "confidence": "high", "evidence": "code path ends in reset()"},
+            ],
+        }
+    print("Running research stage...", flush=True)
+    result = await research_node(state)
+    _print_result("research", result)
+    return result
+
+
 async def main():
     if STAGE == "all":
         await run_all()
@@ -175,6 +212,8 @@ async def main():
         await run_mechanics_only()
     elif STAGE == "reproduction":
         await run_reproduction_only()
+    elif STAGE == "research":
+        await run_research_only()
     else:
         await run_triage_only()
 

--- a/backend/tests/agent/test_bug_reproduction.py
+++ b/backend/tests/agent/test_bug_reproduction.py
@@ -17,6 +17,13 @@ import json
 import sys
 from pathlib import Path
 
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+
+def load_fixture(name: str) -> dict:
+    """Load a bug example fixture by filename stem (e.g. 'openttd_timetable_crash')."""
+    return json.loads((FIXTURES_DIR / f"{name}.json").read_text())
+
 sys.path.insert(0, str(Path(__file__).parent.parent.parent))
 
 from dotenv import load_dotenv
@@ -36,23 +43,20 @@ from evals.bug_evaluators import (
 
 # ── Sample bug description ────────────────────────────────────────────────────
 
-BUG_DESCRIPTION = """\
-After disabling "Show arrival and departure date on timetable" in Settings → Interface → \
-Timetable settings, opening any vehicle's timetable window causes an immediate crash with \
-assertion failure: "cur_height < max_smallest" at widget.cpp line 1578 inside \
-NWidgetHorizontal::SetupSmallestSize(). Reproducible 100% on a fresh game with no mods. \
-Reverting the setting prevents the crash.
-"""
+# Override with a different fixture name via: python -m tests.agent.test_bug_reproduction pipeline openttd_timetable_crash
+_fixture_name = sys.argv[2] if len(sys.argv) > 2 else "openttd_timetable_crash"
+_fixture = load_fixture(_fixture_name)
 
+BUG_DESCRIPTION = _fixture["description"]
 MODE = sys.argv[1] if len(sys.argv) > 1 else "pipeline"
 
 initial_state: BugReproductionState = {
     "description": BUG_DESCRIPTION,
-    "environment": "Windows 11, openttd-15.0-beta3",
-    "severity_input": "high",
-    "repo_name": "OpenTTD",
-    "jira_ticket": None,
-    "attachments": [],
+    "environment": _fixture.get("environment", "unspecified"),
+    "severity_input": _fixture.get("severity_input", "medium"),
+    "repo_name": _fixture.get("repo_name"),
+    "jira_ticket": _fixture.get("jira_ticket"),
+    "attachments": _fixture.get("attachments", []),
     "session_id": "test-bug-stages",
     "repo_stats": {},
     "processes": [],
@@ -147,9 +151,9 @@ async def run_pipeline():
     # Start pipeline
     result = await _stream(run_bug_agent(
         description=BUG_DESCRIPTION,
-        environment="Windows 11, openttd-15.0-beta3",
-        severity_input="high",
-        repo_name="OpenTTD",
+        environment=_fixture.get("environment", "unspecified"),
+        severity_input=_fixture.get("severity_input", "medium"),
+        repo_name=_fixture.get("repo_name"),
         session_id=session_id,
     ))
 

--- a/backend/tests/agent/test_bug_reproduction.py
+++ b/backend/tests/agent/test_bug_reproduction.py
@@ -20,6 +20,7 @@ from agent.stages.bug_triage import triage_node
 from agent.stages.bug_mechanics import mechanics_node as mechanics_analysis_node
 from agent.stages.bug_reproduction import reproduction_node as reproduction_planning_node
 from agent.stages.bug_research import research_node
+from agent.stages.bug_report import report_node
 from evals.bug_evaluators import mechanics_grounding, reproduction_executability, triage_accuracy
 
 # ── Sample bug description ────────────────────────────────────────────────────
@@ -62,6 +63,7 @@ _STAGE_KEY = {
     "mechanics": "mechanics",
     "reproduction": "reproduction_plan",
     "research": "research_findings",
+    "report": "bug_report",
 }
 
 
@@ -205,6 +207,45 @@ async def run_research_only(repro_result: dict | None = None):
     return result
 
 
+async def run_report_only(research_result: dict | None = None):
+    state = {**initial_state}
+    if research_result:
+        state = {**state, **research_result}
+    if not state.get("triage"):
+        state["triage"] = {
+            "bug_category": "gameplay",
+            "keywords": ["fast travel", "equip", "inventory"],
+            "severity": "high",
+            "affected_area": "fast travel / inventory system",
+            "affected_files": [],
+            "initial_hypotheses": ["InventoryManager.reset() called during zone transition"],
+            "confidence": "medium",
+        }
+    if not state.get("mechanics"):
+        state["mechanics"] = {
+            "code_paths": [{"path": "FastTravel.execute→ZoneManager.transition→InventoryManager.reset", "description": "Equipment cleared on transition", "confidence": "high"}],
+            "affected_components": ["FastTravelSystem", "InventoryManager", "ZoneManager"],
+            "root_cause_hypotheses": [
+                {"hypothesis": "InventoryManager.reset() drops equipped items during zone transition", "confidence": "high", "evidence": "code path ends in reset()"},
+            ],
+        }
+    if not state.get("reproduction_plan"):
+        state["reproduction_plan"] = {
+            "steps": [
+                {"step_number": 1, "action": "Equip 6 or more items on your character", "expected_result": "All items show as equipped in the inventory screen"},
+                {"step_number": 2, "action": "Open the world map and select a zone far from your current location", "expected_result": "Fast travel confirmation dialog appears"},
+                {"step_number": 3, "action": "Confirm fast travel", "expected_result": "Player teleports to the destination zone with all items still equipped"},
+            ],
+            "prerequisites": ["Player character with at least 6 item slots filled"],
+            "environment_requirements": ["Windows 10, build 2.4.1-beta"],
+            "confidence": "high",
+        }
+    print("Running report stage...", flush=True)
+    result = await report_node(state)
+    _print_result("report", result)
+    return result
+
+
 async def main():
     if STAGE == "all":
         await run_all()
@@ -214,6 +255,8 @@ async def main():
         await run_reproduction_only()
     elif STAGE == "research":
         await run_research_only()
+    elif STAGE == "report":
+        await run_report_only()
     else:
         await run_triage_only()
 

--- a/backend/tests/agent/test_bug_reproduction.py
+++ b/backend/tests/agent/test_bug_reproduction.py
@@ -1,8 +1,15 @@
 """
-Manual test for bug reproduction stages 1-4.
-Run from backend/: python -m tests.agent.test_bug_reproduction [stage]
+Manual test for the bug reproduction pipeline.
+Run from backend/: python -m tests.agent.test_bug_reproduction [mode]
 
-Stages: triage (default), mechanics, reproduction, research, all
+Modes:
+  pipeline (default) — run full graph through bug_agent (checkpoints auto-approved)
+  stages             — run all 5 stages directly (bypasses graph, no shared MCP client)
+  triage             — run triage stage only
+  mechanics          — run mechanics stage only
+  reproduction       — run reproduction stage only
+  research           — run research stage only
+  report             — run report stage only
 """
 
 import asyncio
@@ -21,24 +28,29 @@ from agent.stages.bug_mechanics import mechanics_node as mechanics_analysis_node
 from agent.stages.bug_reproduction import reproduction_node as reproduction_planning_node
 from agent.stages.bug_research import research_node
 from agent.stages.bug_report import report_node
-from evals.bug_evaluators import mechanics_grounding, reproduction_executability, triage_accuracy
+from evals.bug_evaluators import (
+    triage_accuracy, mechanics_grounding, reproduction_executability,
+    bug_pipeline_health, research_coverage, report_completeness,
+    report_actionability, evidence_quality, tool_efficiency, graceful_degradation,
+)
 
 # ── Sample bug description ────────────────────────────────────────────────────
+
 BUG_DESCRIPTION = """\
-After using the fast travel system to teleport between zones, players lose all equipped \
-items. The items are not deleted — they reappear in the inventory as unequipped. \
-This only happens when the player has more than 5 items equipped simultaneously. \
-The bug is consistent and 100% reproducible. Fast travel via the world map is affected; \
-walking through portals is not.
+After disabling "Show arrival and departure date on timetable" in Settings → Interface → \
+Timetable settings, opening any vehicle's timetable window causes an immediate crash with \
+assertion failure: "cur_height < max_smallest" at widget.cpp line 1578 inside \
+NWidgetHorizontal::SetupSmallestSize(). Reproducible 100% on a fresh game with no mods. \
+Reverting the setting prevents the crash.
 """
 
-STAGE = sys.argv[1] if len(sys.argv) > 1 else "triage"
+MODE = sys.argv[1] if len(sys.argv) > 1 else "pipeline"
 
 initial_state: BugReproductionState = {
     "description": BUG_DESCRIPTION,
-    "environment": "Windows 10, build 2.4.1-beta",
+    "environment": "Windows 11, openttd-15.0-beta3",
     "severity_input": "high",
-    "repo_name": None,
+    "repo_name": "OpenTTD",
     "jira_ticket": None,
     "attachments": [],
     "session_id": "test-bug-stages",
@@ -57,7 +69,6 @@ initial_state: BugReproductionState = {
     "research_context": None,
 }
 
-
 _STAGE_KEY = {
     "triage": "triage",
     "mechanics": "mechanics",
@@ -66,6 +77,8 @@ _STAGE_KEY = {
     "report": "bug_report",
 }
 
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
 
 def _print_result(stage: str, result: dict) -> None:
     print(f"\n{'='*60}")
@@ -83,71 +96,16 @@ def _print_result(stage: str, result: dict) -> None:
         print(f"\n  WARNING: {key} is empty — stage may have hit budget before submitting")
 
 
-async def run_triage_only():
-    print(f"Running triage stage...", flush=True)
-    result = await triage_node(initial_state)
-    _print_result("triage", result)
-    return result
-
-
-async def run_mechanics_only(triage_result: dict | None = None):
-    if mechanics_analysis_node is None:
-        print("mechanics_analysis_node not yet implemented — skipping")
-        return {}
-    state = {**initial_state}
-    if triage_result:
-        state = {**state, **triage_result}
-    elif not state.get("triage"):
-        state["triage"] = {
-            "bug_category": "gameplay",
-            "keywords": ["fast travel", "equip", "inventory", "zone transition"],
-            "severity": "high",
-            "affected_area": "fast travel / inventory system",
-            "affected_files": [],
-            "initial_hypotheses": [
-                "Equipment state is serialized before zone unload but not restored correctly",
-                "Zone transition clears equipped slots without restoring from save",
-            ],
-            "confidence": "medium",
-        }
-    print(f"Running mechanics stage...", flush=True)
-    result = await mechanics_analysis_node(state)
-    _print_result("mechanics", result)
-    return result
-
-
-async def run_reproduction_only(mechanics_result: dict | None = None):
-    if reproduction_planning_node is None:
-        print("reproduction_planning_node not yet implemented — skipping")
-        return {}
-    state = {**initial_state}
-    if mechanics_result:
-        state = {**initial_state, **mechanics_result}
-    elif not state.get("mechanics"):
-        state["triage"] = {
-            "bug_category": "gameplay",
-            "keywords": ["fast travel", "equip", "inventory"],
-            "affected_area": "fast travel / inventory system",
-        }
-        state["mechanics"] = {
-            "code_paths": [{"path": "FastTravel.execute→ZoneManager.transition→InventoryManager.reset", "description": "Equipment state is cleared during zone transition", "confidence": "medium"}],
-            "affected_components": ["FastTravelSystem", "InventoryManager", "ZoneManager"],
-            "entry_points": ["FastTravel.execute"],
-            "root_cause_hypotheses": [
-                {"hypothesis": "InventoryManager.reset() called during zone transition drops equipped items", "confidence": "high", "evidence": "code path ends in reset()"},
-            ],
-        }
-    print(f"Running reproduction stage...", flush=True)
-    result = await reproduction_planning_node(state)
-    _print_result("reproduction", result)
-    return result
-
-
 def _print_evals(combined: dict) -> None:
     print(f"\n{'='*60}")
     print("=== EVALUATOR SCORES ===")
     print(f"{'='*60}")
-    for ev in [triage_accuracy, mechanics_grounding, reproduction_executability]:
+    all_evals = [
+        triage_accuracy, mechanics_grounding, reproduction_executability,
+        bug_pipeline_health, research_coverage, report_completeness,
+        report_actionability, evidence_quality, tool_efficiency, graceful_degradation,
+    ]
+    for ev in all_evals:
         result = ev(combined)
         score_bar = "█" * int(result["score"] * 10) + "░" * (10 - int(result["score"] * 10))
         print(f"\n  {result['key']}")
@@ -155,28 +113,117 @@ def _print_evals(combined: dict) -> None:
         print(f"  summary : {result['comment']}")
         for d in result.get("details", []):
             icon = "✓" if d["passed"] else "✗"
-            print(f"    {icon} {d['check']:<45} {d['value']}")
+            print(f"    {icon} {d['check']:<50} {d['value']}")
 
 
-async def run_all():
-    print("Running full pipeline: triage → mechanics → reproduction\n")
-    triage_result = await triage_node(initial_state)
-    _print_result("triage", triage_result)
+# ── Full pipeline via bug_agent (recommended) ─────────────────────────────────
 
-    state_after_triage = {**initial_state, **triage_result}
-    mechanics_result = await mechanics_analysis_node(state_after_triage)
-    _print_result("mechanics", mechanics_result)
+async def run_pipeline():
+    """Run the full graph through bug_agent — shared MCP client, real checkpoints auto-approved."""
+    from agent.bug_agent import run_bug_agent, continue_bug_agent, BugResultEvent
+    from models import CheckpointEvent, ErrorEvent, StageChangeEvent, AgentStepEvent
 
-    state_after_mechanics = {**state_after_triage, **mechanics_result}
-    repro_result = await reproduction_planning_node(state_after_mechanics)
-    _print_result("reproduction", repro_result)
+    print("Running full pipeline via bug_agent (checkpoints auto-approved)\n")
 
-    total = repro_result.get("tool_calls_used", 0)
-    print(f"\n{'='*60}")
-    print(f"Total tool calls across all stages: {total}")
+    session_id = "test-pipeline-001"
+    combined: dict = {}
+    checkpoint_count = 0
 
-    combined = {**triage_result, **mechanics_result, **repro_result}
+    async def _stream(generator):
+        async for event in generator:
+            if isinstance(event, StageChangeEvent):
+                print(f"\n>>> STAGE: {event.stage}", flush=True)
+            elif isinstance(event, AgentStepEvent):
+                print(f"  → {event.summary}", flush=True)
+            elif isinstance(event, CheckpointEvent):
+                return event
+            elif isinstance(event, BugResultEvent):
+                return event
+            elif isinstance(event, ErrorEvent):
+                print(f"\n!!! ERROR: {event.message}")
+                return None
+        return None
+
+    # Start pipeline
+    result = await _stream(run_bug_agent(
+        description=BUG_DESCRIPTION,
+        environment="Windows 11, openttd-15.0-beta3",
+        severity_input="high",
+        repo_name="OpenTTD",
+        session_id=session_id,
+    ))
+
+    # Auto-approve checkpoints
+    while isinstance(result, CheckpointEvent):
+        checkpoint_count += 1
+        print(f"\n>>> CHECKPOINT [{checkpoint_count}]: {result.interrupt_type}", flush=True)
+        print(f"    stage_completed: {result.stage_completed}", flush=True)
+        print(f"    auto-approving...", flush=True)
+
+        result = await _stream(continue_bug_agent(
+            session_id=result.session_id,
+            user_response={"action": "approve"},
+        ))
+
+    if isinstance(result, BugResultEvent):
+        print(f"\n{'='*60}")
+        print("=== FINAL BUG REPORT ===")
+        print(f"{'='*60}")
+        print(json.dumps(result.bug_report, indent=2))
+        combined = {**result.bug_report, "bug_report": result.bug_report}
+        # Flatten for evaluators
+        combined["tool_calls_used"] = result.bug_report.get("tool_calls_used", 0)
+    else:
+        print("\nPipeline did not produce a result.")
+        return
+
     _print_evals(combined)
+
+
+# ── Individual stage runners (bypass graph, useful for quick iteration) ───────
+
+async def run_triage_only():
+    print("Running triage stage...", flush=True)
+    result = await triage_node(initial_state)
+    _print_result("triage", result)
+    return result
+
+
+async def run_mechanics_only(triage_result: dict | None = None):
+    state = {**initial_state}
+    if triage_result:
+        state = {**state, **triage_result}
+    elif not state.get("triage"):
+        state["triage"] = {
+            "bug_category": "crash",
+            "keywords": ["NWidgetHorizontal", "SetupSmallestSize", "TimetableWindow", "widget assertion"],
+            "severity": "critical",
+            "affected_area": "timetable window UI / widget layout",
+            "affected_files": ["src/timetable_gui.cpp", "src/widget.cpp"],
+            "initial_hypotheses": ["SZSP_NONE on a vertically-filling child inside NWidgetHorizontal violates height invariant"],
+            "confidence": "high",
+        }
+    print("Running mechanics stage...", flush=True)
+    result = await mechanics_analysis_node(state)
+    _print_result("mechanics", result)
+    return result
+
+
+async def run_reproduction_only(mechanics_result: dict | None = None):
+    state = {**initial_state}
+    if mechanics_result:
+        state = {**initial_state, **mechanics_result}
+    elif not state.get("mechanics"):
+        state["triage"] = {"bug_category": "crash", "keywords": ["NWidgetHorizontal"], "affected_area": "widget layout"}
+        state["mechanics"] = {
+            "code_paths": [{"path": "TimetableWindow::UpdateSelectionStates→NWidgetHorizontal::SetupSmallestSize→assert", "description": "assert fires on layout pass", "confidence": "high"}],
+            "affected_components": ["TimetableWindow", "NWidgetHorizontal", "NWidgetStacked"],
+            "root_cause_hypotheses": [{"hypothesis": "SZSP_NONE sets fill_y=1 causing max_smallest to be too tight", "confidence": "high", "evidence": "widget.cpp step 1b loop"}],
+        }
+    print("Running reproduction stage...", flush=True)
+    result = await reproduction_planning_node(state)
+    _print_result("reproduction", result)
+    return result
 
 
 async def run_research_only(repro_result: dict | None = None):
@@ -184,22 +231,11 @@ async def run_research_only(repro_result: dict | None = None):
     if repro_result:
         state = {**state, **repro_result}
     if not state.get("triage"):
-        state["triage"] = {
-            "bug_category": "gameplay",
-            "keywords": ["fast travel", "equip", "inventory", "zone transition"],
-            "severity": "high",
-            "affected_area": "fast travel / inventory system",
-            "affected_files": [],
-            "initial_hypotheses": ["InventoryManager.reset() called during zone transition"],
-            "confidence": "medium",
-        }
+        state["triage"] = {"keywords": ["NWidgetHorizontal", "TimetableWindow"], "affected_area": "timetable widget layout"}
     if not state.get("mechanics"):
         state["mechanics"] = {
-            "code_paths": [{"path": "FastTravel.execute→ZoneManager.transition→InventoryManager.reset", "description": "Equipment cleared on transition", "confidence": "medium"}],
-            "affected_components": ["FastTravelSystem", "InventoryManager", "ZoneManager"],
-            "root_cause_hypotheses": [
-                {"hypothesis": "InventoryManager.reset() drops equipped items during zone transition", "confidence": "high", "evidence": "code path ends in reset()"},
-            ],
+            "affected_components": ["TimetableWindow", "NWidgetHorizontal"],
+            "root_cause_hypotheses": [{"hypothesis": "SZSP_NONE fill_y=1 violates height invariant", "confidence": "high", "evidence": "widget.cpp"}],
         }
     print("Running research stage...", flush=True)
     result = await research_node(state)
@@ -212,32 +248,22 @@ async def run_report_only(research_result: dict | None = None):
     if research_result:
         state = {**state, **research_result}
     if not state.get("triage"):
-        state["triage"] = {
-            "bug_category": "gameplay",
-            "keywords": ["fast travel", "equip", "inventory"],
-            "severity": "high",
-            "affected_area": "fast travel / inventory system",
-            "affected_files": [],
-            "initial_hypotheses": ["InventoryManager.reset() called during zone transition"],
-            "confidence": "medium",
-        }
+        state["triage"] = {"bug_category": "crash", "severity": "critical", "affected_area": "widget layout", "keywords": ["NWidgetHorizontal"]}
     if not state.get("mechanics"):
         state["mechanics"] = {
-            "code_paths": [{"path": "FastTravel.execute→ZoneManager.transition→InventoryManager.reset", "description": "Equipment cleared on transition", "confidence": "high"}],
-            "affected_components": ["FastTravelSystem", "InventoryManager", "ZoneManager"],
-            "root_cause_hypotheses": [
-                {"hypothesis": "InventoryManager.reset() drops equipped items during zone transition", "confidence": "high", "evidence": "code path ends in reset()"},
-            ],
+            "code_paths": [{"path": "UpdateSelectionStates→SetupSmallestSize→assert", "description": "assert on layout", "confidence": "high"}],
+            "affected_components": ["TimetableWindow", "NWidgetHorizontal"],
+            "root_cause_hypotheses": [{"hypothesis": "SZSP_NONE fill_y=1 violates height invariant", "confidence": "high", "evidence": "widget.cpp step 1b"}],
         }
     if not state.get("reproduction_plan"):
         state["reproduction_plan"] = {
             "steps": [
-                {"step_number": 1, "action": "Equip 6 or more items on your character", "expected_result": "All items show as equipped in the inventory screen"},
-                {"step_number": 2, "action": "Open the world map and select a zone far from your current location", "expected_result": "Fast travel confirmation dialog appears"},
-                {"step_number": 3, "action": "Confirm fast travel", "expected_result": "Player teleports to the destination zone with all items still equipped"},
+                {"step_number": 1, "action": "Start OpenTTD with no mods", "expected_result": "Game loads normally"},
+                {"step_number": 2, "action": "Disable 'Show arrival and departure date' in Settings", "expected_result": "Setting toggles off"},
+                {"step_number": 3, "action": "Open any vehicle timetable window", "expected_result": "Game crashes with assertion failure"},
             ],
-            "prerequisites": ["Player character with at least 6 item slots filled"],
-            "environment_requirements": ["Windows 10, build 2.4.1-beta"],
+            "prerequisites": ["Vanilla OpenTTD installation"],
+            "environment_requirements": ["Debug build recommended"],
             "confidence": "high",
         }
     print("Running report stage...", flush=True)
@@ -246,16 +272,51 @@ async def run_report_only(research_result: dict | None = None):
     return result
 
 
+async def run_stages():
+    """Run all 5 stages directly in sequence (no graph, no shared client)."""
+    print("Running all stages directly: triage → mechanics → reproduction → research → report\n")
+
+    triage_result = await triage_node(initial_state)
+    _print_result("triage", triage_result)
+
+    state_after_triage = {**initial_state, **triage_result}
+    mechanics_result = await mechanics_analysis_node(state_after_triage)
+    _print_result("mechanics", mechanics_result)
+
+    state_after_mechanics = {**state_after_triage, **mechanics_result}
+    repro_result = await reproduction_planning_node(state_after_mechanics)
+    _print_result("reproduction", repro_result)
+
+    state_after_repro = {**state_after_mechanics, **repro_result}
+    research_result = await research_node(state_after_repro)
+    _print_result("research", research_result)
+
+    state_after_research = {**state_after_repro, **research_result}
+    report_result = await report_node(state_after_research)
+    _print_result("report", report_result)
+
+    total = report_result.get("tool_calls_used", 0)
+    print(f"\n{'='*60}")
+    print(f"Total tool calls across all stages: {total}")
+
+    combined = {**triage_result, **mechanics_result, **repro_result, **research_result, **report_result}
+    _print_evals(combined)
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
 async def main():
-    if STAGE == "all":
-        await run_all()
-    elif STAGE == "mechanics":
+    if MODE == "pipeline":
+        await run_pipeline()
+    elif MODE == "stages":
+        await run_stages()
+    elif MODE == "mechanics":
         await run_mechanics_only()
-    elif STAGE == "reproduction":
+    elif MODE == "reproduction":
         await run_reproduction_only()
-    elif STAGE == "research":
+    elif MODE == "research":
         await run_research_only()
-    elif STAGE == "report":
+    elif MODE == "report":
         await run_report_only()
     else:
         await run_triage_only()

--- a/backend/tests/agent/test_bug_reproduction.py
+++ b/backend/tests/agent/test_bug_reproduction.py
@@ -170,9 +170,8 @@ async def run_pipeline():
         print("=== FINAL BUG REPORT ===")
         print(f"{'='*60}")
         print(json.dumps(result.bug_report, indent=2))
-        combined = {**result.bug_report, "bug_report": result.bug_report}
-        # Flatten for evaluators
-        combined["tool_calls_used"] = result.bug_report.get("tool_calls_used", 0)
+        # Use full_state so evaluators can access triage/mechanics/reproduction_plan/research_findings
+        combined = result.full_state if result.full_state else {"bug_report": result.bug_report}
     else:
         print("\nPipeline did not produce a result.")
         return

--- a/frontend/src/components/BugCheckpointDialog.tsx
+++ b/frontend/src/components/BugCheckpointDialog.tsx
@@ -1,0 +1,288 @@
+import { useState } from 'react';
+import { X, CheckCircle, MessageSquare, RefreshCw, AlertTriangle } from '@/lib/lucide-icons';
+import type { CheckpointData } from '../services/types';
+
+// ── Typed shapes for intermediate_result ─────────────────────────────────────
+
+interface MechanicsResult {
+  affected_components: string[];
+  root_cause_hypotheses: Array<{
+    hypothesis: string;
+    confidence: string;
+    evidence: string;
+  }>;
+  code_paths: Array<{
+    path: string;
+    description: string;
+    confidence: string;
+  }>;
+}
+
+interface ResearchResult {
+  sources_queried: string[];
+  sources_with_results: string[];
+  related_issues_count: number;
+  log_entries_count: number;
+  doc_references_count: number;
+}
+
+// ── Props ─────────────────────────────────────────────────────────────────────
+
+interface BugCheckpointDialogProps {
+  checkpoint: CheckpointData;
+  /** Mechanics: action is 'approve' | 'refine' (+ feedback).
+   *  Research:  action is 'approve' | 'add_context' (+ context). */
+  onContinue: (response: Record<string, string>) => void;
+  onDismiss: () => void;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const CONFIDENCE_COLORS: Record<string, string> = {
+  high:   'bg-emerald-500/15 text-emerald-400 border-emerald-500/30',
+  medium: 'bg-amber-500/15 text-amber-400 border-amber-500/30',
+  low:    'bg-red-500/15 text-red-400 border-red-500/30',
+};
+
+function ConfidenceBadge({ value }: { value: string }) {
+  const cls = CONFIDENCE_COLORS[value.toLowerCase()] ?? CONFIDENCE_COLORS.low;
+  return (
+    <span className={`rounded border px-1.5 py-0.5 text-[10px] font-medium ${cls}`}>
+      {value}
+    </span>
+  );
+}
+
+// ── Post-mechanics body ───────────────────────────────────────────────────────
+
+function MechanicsBody({ result }: { result: MechanicsResult }) {
+  return (
+    <div className="space-y-4">
+      {/* Affected components */}
+      {result.affected_components.length > 0 && (
+        <div>
+          <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-text-muted">
+            Affected components
+          </p>
+          <div className="flex flex-wrap gap-1.5">
+            {result.affected_components.map((c) => (
+              <span
+                key={c}
+                className="rounded border border-accent/30 bg-accent/10 px-2 py-0.5 font-mono text-[11px] text-accent"
+              >
+                {c}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* Root cause hypotheses */}
+      {result.root_cause_hypotheses.length > 0 && (
+        <div>
+          <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-text-muted">
+            Root cause hypotheses
+          </p>
+          <div className="space-y-2">
+            {result.root_cause_hypotheses.map((h, i) => (
+              <div
+                key={i}
+                className="rounded border border-border-subtle bg-deep px-3 py-2.5"
+              >
+                <div className="mb-1.5 flex items-start justify-between gap-2">
+                  <span className="text-xs leading-relaxed text-text-primary">{h.hypothesis}</span>
+                  <ConfidenceBadge value={h.confidence} />
+                </div>
+                {h.evidence && (
+                  <p className="text-[11px] leading-relaxed text-text-muted line-clamp-2">
+                    {h.evidence}
+                  </p>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Post-research body ────────────────────────────────────────────────────────
+
+function ResearchBody({ result }: { result: ResearchResult }) {
+  const allSources = result.sources_queried;
+  const withResults = new Set(result.sources_with_results);
+  const evidenceItems = [
+    { label: 'Log entries',      count: result.log_entries_count },
+    { label: 'Doc references',   count: result.doc_references_count },
+    { label: 'Related issues',   count: result.related_issues_count },
+  ];
+  const totalEvidence =
+    result.log_entries_count + result.doc_references_count + result.related_issues_count;
+
+  return (
+    <div className="space-y-4">
+      {/* Sources */}
+      <div>
+        <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-text-muted">
+          Sources queried
+        </p>
+        {allSources.length === 0 ? (
+          <p className="text-xs text-text-muted">No external sources were queried.</p>
+        ) : (
+          <div className="flex flex-wrap gap-1.5">
+            {allSources.map((s) => {
+              const hit = withResults.has(s);
+              return (
+                <span
+                  key={s}
+                  className={`flex items-center gap-1 rounded border px-2 py-0.5 text-[11px] ${
+                    hit
+                      ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400'
+                      : 'border-border-subtle bg-elevated text-text-muted'
+                  }`}
+                >
+                  {hit ? (
+                    <CheckCircle className="h-2.5 w-2.5" />
+                  ) : (
+                    <span className="h-2.5 w-2.5 text-center leading-none">—</span>
+                  )}
+                  {s}
+                </span>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* Evidence counts */}
+      <div>
+        <p className="mb-2 text-[11px] font-medium uppercase tracking-wider text-text-muted">
+          Evidence collected
+        </p>
+        {totalEvidence === 0 ? (
+          <div className="flex items-center gap-2 rounded border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-xs text-amber-400">
+            <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+            No external evidence found — report will rely on code analysis only.
+          </div>
+        ) : (
+          <div className="grid grid-cols-3 gap-2">
+            {evidenceItems.map(({ label, count }) => (
+              <div
+                key={label}
+                className="rounded border border-border-subtle bg-deep px-3 py-2 text-center"
+              >
+                <p className="text-lg font-semibold text-text-primary">{count}</p>
+                <p className="text-[10px] text-text-muted">{label}</p>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export const BugCheckpointDialog = ({ checkpoint, onContinue, onDismiss }: BugCheckpointDialogProps) => {
+  const [inputText, setInputText] = useState('');
+  const [showInput, setShowInput] = useState(false);
+
+  const checkpointType = checkpoint.payload?.type as string | undefined;
+  const isMechanics = checkpointType === 'checkpoint_mechanics';
+  const result = checkpoint.payload?.intermediate_result as MechanicsResult | ResearchResult | undefined;
+
+  const secondaryLabel = isMechanics ? 'Refine' : 'Add Context';
+  const secondaryPlaceholder = isMechanics
+    ? 'Describe what to investigate further or correct…'
+    : 'Add context, logs, or additional details for the research stage…';
+
+  function handleSecondary() {
+    if (!showInput) {
+      setShowInput(true);
+      return;
+    }
+    if (isMechanics) {
+      onContinue({ action: 'refine', feedback: inputText });
+    } else {
+      onContinue({ action: 'add_context', context: inputText });
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+      <div className="animate-slide-up w-full max-w-lg rounded-xl border border-border-default bg-elevated shadow-glow">
+
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-border-subtle px-5 py-4">
+          <div className="flex items-center gap-2">
+            <div className="h-2 w-2 animate-pulse rounded-full bg-amber-400" />
+            <span className="text-sm font-medium text-text-primary">
+              {isMechanics ? 'Mechanics Review' : 'Research Review'}
+            </span>
+          </div>
+          <button
+            onClick={onDismiss}
+            className="rounded p-1 text-text-muted transition-colors hover:bg-hover hover:text-text-primary"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="max-h-[60vh] overflow-y-auto px-5 py-4">
+          {result && isMechanics && (
+            <MechanicsBody result={result as MechanicsResult} />
+          )}
+          {result && !isMechanics && (
+            <ResearchBody result={result as ResearchResult} />
+          )}
+
+          {/* Refine / Add Context textarea */}
+          {showInput && (
+            <div className="mt-4">
+              <textarea
+                value={inputText}
+                onChange={(e) => setInputText(e.target.value)}
+                placeholder={secondaryPlaceholder}
+                rows={3}
+                className="w-full rounded border border-border-subtle bg-deep px-3 py-2 text-xs text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+                autoFocus
+              />
+            </div>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="flex flex-wrap gap-2 border-t border-border-subtle px-5 py-4">
+          <button
+            onClick={() => onContinue({ action: 'approve' })}
+            className="flex items-center gap-2 rounded-lg bg-emerald-500/20 px-4 py-2 text-sm font-medium text-emerald-400 transition-colors hover:bg-emerald-500/30"
+          >
+            <CheckCircle className="h-4 w-4" />
+            Approve &amp; Continue
+          </button>
+
+          <button
+            onClick={handleSecondary}
+            className="flex items-center gap-2 rounded-lg bg-accent/20 px-4 py-2 text-sm font-medium text-accent transition-colors hover:bg-accent/30"
+          >
+            <MessageSquare className="h-4 w-4" />
+            {showInput ? `Submit ${secondaryLabel}` : secondaryLabel}
+          </button>
+
+          {isMechanics && showInput && (
+            <button
+              onClick={() => { setShowInput(false); setInputText(''); }}
+              className="flex items-center gap-2 rounded-lg border border-border-subtle bg-elevated px-4 py-2 text-sm text-text-secondary transition-colors hover:bg-hover hover:text-text-primary"
+            >
+              <RefreshCw className="h-4 w-4" />
+              Cancel
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/components/ResearchPanel.tsx
+++ b/frontend/src/components/ResearchPanel.tsx
@@ -1,0 +1,377 @@
+import { useState } from 'react';
+import { CheckCircle, AlertTriangle, MessageSquare, RefreshCw } from '@/lib/lucide-icons';
+import type { CheckpointData } from '../services/types';
+
+// ── Data shapes ───────────────────────────────────────────────────────────────
+
+interface LogEntry {
+  timestamp?: string;
+  level?: string;
+  message: string;
+  source?: string;
+}
+
+interface DocReference {
+  title: string;
+  url?: string;
+  excerpt?: string;
+}
+
+interface RelatedIssue {
+  id?: string;
+  title: string;
+  url?: string;
+  status?: string;
+  relevance?: string;
+}
+
+interface NetworkTrace {
+  url?: string;
+  method?: string;
+  status_code?: number;
+  error?: string;
+}
+
+interface ResearchFindings {
+  log_entries: LogEntry[];
+  doc_references: DocReference[];
+  related_issues: RelatedIssue[];
+  network_traces: NetworkTrace[];
+  sources_queried: string[];
+  sources_with_results: string[];
+}
+
+// ── Props ─────────────────────────────────────────────────────────────────────
+
+interface ResearchPanelProps {
+  checkpoint: CheckpointData;
+  onApprove: () => void;
+  onAddContext: (context: string) => void;
+}
+
+// ── Tab types ─────────────────────────────────────────────────────────────────
+
+type Tab = 'logs' | 'docs' | 'issues' | 'network';
+
+const LEVEL_COLORS: Record<string, string> = {
+  error:   'text-red-400 bg-red-500/10 border-red-500/30',
+  warn:    'text-amber-400 bg-amber-500/10 border-amber-500/30',
+  warning: 'text-amber-400 bg-amber-500/10 border-amber-500/30',
+  info:    'text-blue-400 bg-blue-500/10 border-blue-500/30',
+  debug:   'text-text-muted bg-elevated border-border-subtle',
+};
+
+function levelStyle(level?: string) {
+  return LEVEL_COLORS[(level ?? '').toLowerCase()] ?? LEVEL_COLORS.debug;
+}
+
+// ── Tab panels ────────────────────────────────────────────────────────────────
+
+function LogsTab({ entries }: { entries: LogEntry[] }) {
+  if (entries.length === 0) {
+    return <EmptyState message="No log entries found" />;
+  }
+  return (
+    <div className="flex flex-col gap-1.5">
+      {entries.map((entry, i) => (
+        <div key={i} className="rounded border border-border-subtle bg-elevated px-3 py-2">
+          <div className="mb-1 flex items-center gap-2">
+            {entry.level && (
+              <span className={`rounded border px-1.5 py-0.5 font-mono text-[9px] font-medium uppercase ${levelStyle(entry.level)}`}>
+                {entry.level}
+              </span>
+            )}
+            {entry.source && (
+              <span className="text-[10px] text-text-muted">{entry.source}</span>
+            )}
+            {entry.timestamp && (
+              <span className="ml-auto font-mono text-[10px] text-text-muted">{entry.timestamp}</span>
+            )}
+          </div>
+          <p className="font-mono text-[11px] leading-relaxed text-text-primary">{entry.message}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function DocsTab({ refs }: { refs: DocReference[] }) {
+  if (refs.length === 0) {
+    return <EmptyState message="No documentation references found" />;
+  }
+  return (
+    <div className="flex flex-col gap-2">
+      {refs.map((doc, i) => (
+        <div key={i} className="rounded border border-border-subtle bg-elevated px-3 py-2.5">
+          <div className="mb-1 flex items-start justify-between gap-2">
+            <span className="text-xs font-medium text-text-primary">{doc.title}</span>
+            {doc.url && (
+              <a
+                href={doc.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="shrink-0 font-mono text-[10px] text-accent hover:underline"
+              >
+                link ↗
+              </a>
+            )}
+          </div>
+          {doc.excerpt && (
+            <p className="text-[11px] leading-relaxed text-text-muted line-clamp-3">{doc.excerpt}</p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function IssuesTab({ issues }: { issues: RelatedIssue[] }) {
+  if (issues.length === 0) {
+    return <EmptyState message="No related issues found" />;
+  }
+  return (
+    <div className="flex flex-col gap-2">
+      {issues.map((issue, i) => (
+        <div key={i} className="rounded border border-border-subtle bg-elevated px-3 py-2.5">
+          <div className="mb-1 flex items-start gap-2">
+            {issue.id && (
+              <span className="shrink-0 font-mono text-[10px] text-accent">{issue.id}</span>
+            )}
+            <span className="flex-1 text-xs font-medium text-text-primary">{issue.title}</span>
+            {issue.status && (
+              <span className="shrink-0 rounded border border-border-subtle bg-deep px-1.5 py-0.5 text-[10px] text-text-muted">
+                {issue.status}
+              </span>
+            )}
+          </div>
+          {issue.relevance && (
+            <p className="text-[11px] leading-relaxed text-text-muted">{issue.relevance}</p>
+          )}
+          {issue.url && (
+            <a
+              href={issue.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-1 block font-mono text-[10px] text-accent hover:underline"
+            >
+              {issue.url}
+            </a>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function NetworkTab({ traces }: { traces: NetworkTrace[] }) {
+  if (traces.length === 0) {
+    return <EmptyState message="No network traces captured" />;
+  }
+  return (
+    <div className="flex flex-col gap-1.5">
+      {traces.map((trace, i) => {
+        const isError = trace.status_code ? trace.status_code >= 400 : !!trace.error;
+        return (
+          <div
+            key={i}
+            className={`rounded border px-3 py-2 ${
+              isError
+                ? 'border-red-500/30 bg-red-500/5'
+                : 'border-border-subtle bg-elevated'
+            }`}
+          >
+            <div className="flex items-center gap-2">
+              {trace.method && (
+                <span className="font-mono text-[10px] font-bold text-accent">{trace.method}</span>
+              )}
+              {trace.status_code !== undefined && (
+                <span className={`font-mono text-[10px] font-medium ${isError ? 'text-red-400' : 'text-emerald-400'}`}>
+                  {trace.status_code}
+                </span>
+              )}
+              {trace.url && (
+                <span className="flex-1 truncate font-mono text-[11px] text-text-muted">{trace.url}</span>
+              )}
+            </div>
+            {trace.error && (
+              <p className="mt-1 font-mono text-[10px] text-red-400">{trace.error}</p>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function EmptyState({ message }: { message: string }) {
+  return (
+    <div className="flex items-center gap-2 rounded border border-border-subtle bg-elevated/30 px-3 py-6">
+      <p className="w-full text-center text-xs text-text-muted">{message}</p>
+    </div>
+  );
+}
+
+// ── Sources bar ───────────────────────────────────────────────────────────────
+
+function SourcesBar({ queried, withResults }: { queried: string[]; withResults: string[] }) {
+  if (queried.length === 0) return null;
+  const hitSet = new Set(withResults);
+  return (
+    <div className="flex flex-wrap gap-1.5 px-5 py-2.5 border-b border-border-subtle">
+      {queried.map((s) => {
+        const hit = hitSet.has(s);
+        return (
+          <span
+            key={s}
+            className={`flex items-center gap-1 rounded border px-2 py-0.5 text-[11px] ${
+              hit
+                ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-400'
+                : 'border-border-subtle bg-elevated text-text-muted'
+            }`}
+          >
+            {hit ? <CheckCircle className="h-2.5 w-2.5" /> : <span className="h-2.5 w-2.5 text-center leading-none">—</span>}
+            {s}
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+export const ResearchPanel = ({ checkpoint, onApprove, onAddContext }: ResearchPanelProps) => {
+  const [activeTab, setActiveTab] = useState<Tab>('logs');
+  const [context, setContext] = useState('');
+  const [showContext, setShowContext] = useState(false);
+
+  const findings = (checkpoint.payload?.intermediate_result ?? {}) as Partial<ResearchFindings>;
+  const logEntries   = findings.log_entries    ?? [];
+  const docRefs      = findings.doc_references  ?? [];
+  const issues       = findings.related_issues  ?? [];
+  const netTraces    = findings.network_traces   ?? [];
+  const queried      = findings.sources_queried  ?? [];
+  const withResults  = findings.sources_with_results ?? [];
+
+  const totalEvidence = logEntries.length + docRefs.length + issues.length + netTraces.length;
+
+  const tabs: { id: Tab; label: string; count: number }[] = [
+    { id: 'logs',    label: 'Logs',    count: logEntries.length },
+    { id: 'docs',    label: 'Docs',    count: docRefs.length    },
+    { id: 'issues',  label: 'Issues',  count: issues.length     },
+    { id: 'network', label: 'Network', count: netTraces.length  },
+  ];
+
+  return (
+    <div className="flex h-full flex-col bg-surface">
+      {/* Header */}
+      <div className="shrink-0 border-b border-border-subtle bg-elevated/50 px-5 py-3">
+        <div className="flex items-center gap-2">
+          <div className="h-2 w-2 animate-pulse rounded-full bg-amber-400" />
+          <span className="text-sm font-medium text-text-primary">Research Review</span>
+        </div>
+        <p className="mt-1 text-[11px] text-text-muted">
+          {queried.length} source{queried.length !== 1 ? 's' : ''} queried
+          {totalEvidence > 0 ? ` · ${totalEvidence} evidence item${totalEvidence !== 1 ? 's' : ''}` : ''}
+        </p>
+      </div>
+
+      {/* Sources bar */}
+      <SourcesBar queried={queried} withResults={withResults} />
+
+      {/* No-evidence warning */}
+      {totalEvidence === 0 && (
+        <div className="mx-4 mt-3 flex items-center gap-2 rounded border border-amber-500/20 bg-amber-500/5 px-3 py-2 text-xs text-amber-400">
+          <AlertTriangle className="h-3.5 w-3.5 shrink-0" />
+          No external evidence found — report will rely on code analysis only.
+        </div>
+      )}
+
+      {/* Tabs */}
+      <div className="shrink-0 flex gap-0 border-b border-border-subtle px-4 pt-3">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            className={`flex items-center gap-1.5 border-b-2 px-3 pb-2 text-xs transition-colors ${
+              activeTab === tab.id
+                ? 'border-accent text-text-primary'
+                : 'border-transparent text-text-muted hover:text-text-secondary'
+            }`}
+          >
+            {tab.label}
+            {tab.count > 0 && (
+              <span className={`rounded px-1 py-0.5 text-[9px] font-medium ${
+                activeTab === tab.id ? 'bg-accent/20 text-accent' : 'bg-elevated text-text-muted'
+              }`}>
+                {tab.count}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Tab content */}
+      <div className="scrollbar-thin flex-1 overflow-y-auto p-4">
+        {activeTab === 'logs'    && <LogsTab    entries={logEntries} />}
+        {activeTab === 'docs'    && <DocsTab    refs={docRefs}       />}
+        {activeTab === 'issues'  && <IssuesTab  issues={issues}      />}
+        {activeTab === 'network' && <NetworkTab traces={netTraces}   />}
+      </div>
+
+      {/* Action bar */}
+      <div className="shrink-0 border-t border-border-subtle bg-elevated/50 px-4 py-3">
+        {showContext && (
+          <div className="mb-3">
+            <textarea
+              value={context}
+              onChange={(e) => setContext(e.target.value)}
+              placeholder="Add context, logs, or additional details for the research stage…"
+              rows={3}
+              autoFocus
+              className="w-full rounded border border-border-subtle bg-deep px-3 py-2 text-xs text-text-primary placeholder:text-text-muted focus:border-accent focus:outline-none"
+            />
+          </div>
+        )}
+
+        <div className="flex flex-wrap gap-2">
+          <button
+            onClick={onApprove}
+            className="flex items-center gap-2 rounded-lg bg-emerald-500/20 px-4 py-2 text-sm font-medium text-emerald-400 transition-colors hover:bg-emerald-500/30"
+          >
+            <CheckCircle className="h-4 w-4" />
+            Approve &amp; Continue
+          </button>
+
+          {showContext ? (
+            <>
+              <button
+                onClick={() => { if (context.trim()) onAddContext(context.trim()); }}
+                disabled={!context.trim()}
+                className="flex items-center gap-2 rounded-lg bg-accent/20 px-4 py-2 text-sm font-medium text-accent transition-colors hover:bg-accent/30 disabled:opacity-40"
+              >
+                <MessageSquare className="h-4 w-4" />
+                Submit Context
+              </button>
+              <button
+                onClick={() => { setShowContext(false); setContext(''); }}
+                className="flex items-center gap-2 rounded-lg border border-border-subtle bg-elevated px-4 py-2 text-sm text-text-secondary transition-colors hover:bg-hover hover:text-text-primary"
+              >
+                <RefreshCw className="h-4 w-4" />
+                Cancel
+              </button>
+            </>
+          ) : (
+            <button
+              onClick={() => setShowContext(true)}
+              className="flex items-center gap-2 rounded-lg bg-accent/20 px-4 py-2 text-sm font-medium text-accent transition-colors hover:bg-accent/30"
+            >
+              <MessageSquare className="h-4 w-4" />
+              Add Context
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
                                                                                                                                                                                                                                                                                
  - Bug reproduction pipeline (stages 4–5): Implemented bug_research.py (research stage, 20-call budget, multi-source evidence collection) and bug_report.py (report generation stage, assembles final BugReport from all stage outputs).
  - StateGraph wiring (bug_agent.py): Full LangGraph StateGraph with 8 nodes, conditional edges, both checkpoint nodes (checkpoint_mechanics, checkpoint_research), run_bug_agent() and continue_bug_agent() async entry points with SSE streaming.                             
  - Bug prompts: Added BUG_BASE_PROMPT, BUG_TRIAGE_PROMPT, BUG_MECHANICS_PROMPT, BUG_REPRODUCTION_PROMPT, BUG_RESEARCH_PROMPT, BUG_REPORT_PROMPT to prompts.py.                                                                                                                 
  - Context overflow fix (all stages): Replaced broken coroutine-wrapping approach with make_messages_modifier — a pre_model_hook that truncates ToolMessage content at 12k chars before each LLM call. Applied across all 5 bug stages and 3 existing PR stages. Also added    
  fix_dangling_tool_calls to repair invalid chat history when the stream is broken mid-parallel-tool-call.                                                                                                                                                                      
  - Evaluators: 7 evaluators for stages 4–5 and pipeline-level health: research_coverage, report_completeness, report_actionability, evidence_quality, tool_efficiency, graceful_degradation, bug_pipeline_health.                                                              
  - Golden dataset: Added BUG_EXAMPLES to create_dataset.py with the OpenTTD timetable crash example (ground truth root cause, affected files, components).                                                                                                                     
  - Test fixture + runner: fixtures/openttd_timetable_crash.json with full ground truth; test_bug_reproduction.py extended to support multiple fixtures and all 5 individual stage modes.                                                                                       
  - Frontend — BugCheckpointDialog.tsx: Two checkpoint variants — post-mechanics (affected components + confidence-ranked root cause hypotheses + approve/refine) and post-research (per-source evidence summary + approve/add-context).                                        
  - Frontend — ResearchPanel.tsx: Tabbed research findings panel (Logs / Docs / Issues / Network), per-source count badges, sources bar with hit/miss indicators, amber warning for zero evidence, inline add-context flow.   