### PR TITLE
Sprint 3 Person 3: bug API, models, export, Jira MCP...

### DIFF
--- a/backend/agent/agent.py
+++ b/backend/agent/agent.py
@@ -277,6 +277,11 @@ def _get_graph():
 
 _sessions: dict[str, dict] = {}
 
+
+def has_analysis_thread(session_id: str) -> bool:
+    """True if a PR analysis run was started for this id (in-memory, same as checkpointer thread)."""
+    return session_id in _sessions
+
 # ── Stage node names (for StageChangeEvent filtering) ────────────────────────
 
 _STAGE_NODES = {
@@ -288,7 +293,12 @@ _llm = ChatAnthropic(
     model="claude-sonnet-4-6",
     temperature=0,
     max_tokens=4096,
-    api_key=os.environ.get("ANTHROPIC_AUTH_TOKEN") or os.environ.get("ANTHROPIC_API_KEY"),
+    # Placeholder allows import in CI / tests; real calls still need a valid key in env.
+    api_key=(
+        os.environ.get("ANTHROPIC_AUTH_TOKEN")
+        or os.environ.get("ANTHROPIC_API_KEY")
+        or "dummy-not-configured"
+    ),
     base_url=os.environ.get("ANTHROPIC_BASE_URL"),
 )
 

--- a/backend/agent/bug_agent.py
+++ b/backend/agent/bug_agent.py
@@ -1,0 +1,604 @@
+"""
+Bug reproduction LangGraph entrypoints and final BugReport assembly.
+
+Yields Server-Sent Events matching Sprint 3 bug_* Pydantic models in models.py.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import traceback
+from typing import Any, AsyncIterator, Literal
+
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.graph import END, StateGraph
+from langgraph.types import Command, interrupt
+
+from agent.agent import _extract_owner_repo, _llm
+from agent.agent import BugReproductionState
+from agent.prefetch import prefetch_context
+from agent.bug_run_registry import clear_bug_runs, is_active_bug_run, mark_bug_run_started
+from agent.sessions import SessionType, create_session, get_session, update_session
+from agent.stages.bug_mechanics import mechanics_node
+from agent.stages.bug_reproduction import reproduction_node
+from agent.stages.bug_triage import triage_node
+from indexer import get_repo_name
+from models import (
+    AffectedComponent,
+    BugCheckpointEvent,
+    BugReport,
+    BugReportResultEvent,
+    BugStageChangeEvent,
+    E2ETestStep,
+    ErrorEvent,
+    ResearchFindings,
+    ResearchProgressEvent,
+)
+
+_bug_graph: Any = None
+
+BUG_NODE_NAMES: set[str] = {
+    "bug_triage",
+    "bug_mechanics",
+    "bug_checkpoint_mech",
+    "bug_reproduction",
+    "bug_research",
+    "bug_checkpoint_research",
+    "bug_final",
+}
+
+TIMEOUT_SECONDS = 600
+
+
+def _repo_name_for_bug(repo_url: str | None) -> str | None:
+    if not repo_url:
+        return None
+    if "/pull/" in repo_url:
+        o_r = _extract_owner_repo(repo_url)
+        if o_r:
+            return get_repo_name(f"{o_r[0]}/{o_r[1]}")
+    m = re.search(r"github\.com/([^/]+)/([^/]+)", repo_url)
+    if m:
+        return get_repo_name(f"{m.group(1)}/{m.group(2)}")
+    return None
+
+
+def _map_severity(raw: str | None) -> Literal["critical", "major", "minor", "trivial"]:
+    s = (raw or "major").lower()
+    if s == "critical":
+        return "critical"
+    if s in ("high", "major", "medium"):
+        return "major"
+    if s in ("low", "minor"):
+        return "minor"
+    if s == "trivial":
+        return "trivial"
+    return "major"
+
+
+def _coerce_confidence(
+    t: Any,
+) -> Literal["high", "medium", "low"]:
+    c = str(
+        t.get("confidence", "medium") or "medium"
+    ).lower()
+    if c in ("high", "medium", "low"):
+        return c  # type: ignore[return-value]
+    return "medium"
+
+
+def assemble_bug_report(
+    state: dict,
+) -> BugReport:
+    t = state.get("triage") or {}
+    m = state.get("mechanics") or {}
+    r = state.get("reproduction_plan") or {}
+    rf_raw = state.get("research_findings") or {}
+    if isinstance(rf_raw, dict):
+        try:
+            evidence = ResearchFindings.model_validate(rf_raw)
+        except Exception:
+            evidence = ResearchFindings(
+                evidence_summary=str(rf_raw.get("evidence_summary", "")) or "Research (partial).",
+            )
+    else:
+        evidence = ResearchFindings(evidence_summary="Research (partial).")
+
+    title = (f"[{t.get('bug_category')}] " if t.get("bug_category") else "")
+    desc = (state.get("description") or "Bug report")[:200]
+    title = (title + desc).strip() or "Bug report"
+
+    ac_raw = m.get("affected_components", []) or []
+    affected: list[AffectedComponent] = []
+    for c in ac_raw if isinstance(ac_raw, list) else []:
+        if isinstance(c, str):
+            affected.append(
+                AffectedComponent(
+                    component=c, files_changed=[
+                        f for f in t.get("affected_files", []) or []
+                        if f == c or c in str(f)
+                    ][:1]
+                    or (t.get("affected_files", []) or []),
+                )
+            )
+        elif isinstance(c, dict) and c.get("component"):
+            try:
+                affected.append(AffectedComponent.model_validate(c))
+            except Exception:
+                affected.append(AffectedComponent(component=str(c.get("component", "Unknown"))))
+
+    if not affected:
+        for fn in t.get("affected_files", []) or []:
+            if isinstance(fn, str):
+                affected.append(
+                    AffectedComponent(
+                        component=fn,
+                        files_changed=[fn],
+                        impact_summary="Mentioned in triage.",
+                    )
+                )
+    if not affected:
+        affected.append(AffectedComponent(component="Unknown", files_changed=[]))
+
+    steps: list[E2ETestStep] = []
+    for i, s in enumerate(r.get("steps", []) or []):
+        if not isinstance(s, dict):
+            continue
+        sn = s.get("step_number", s.get("step", i + 1))
+        try:
+            n = int(sn) if sn is not None else i + 1
+        except (TypeError, ValueError):
+            n = i + 1
+        steps.append(
+            E2ETestStep(
+                step=n,
+                action=str(s.get("action", s.get("description", "")) or "Step"),
+                expected=str(
+                    s.get("expected_result", s.get("expected", "See actual behavior."))
+                ),
+            )
+        )
+    if not steps:
+        steps = [
+            E2ETestStep(
+                step=1,
+                action="Reproduce the issue using the preconditions in the plan.",
+                expected="Issue reproduces or expected behavior observed.",
+            )
+        ]
+
+    hyps: list = m.get("root_cause_hypotheses", []) or []
+    hyp_lines: list[str] = []
+    for h in hyps if isinstance(hyps, list) else []:
+        if isinstance(h, dict):
+            hyp_lines.append(str(h.get("hypothesis", h.get("text", h))) or str(h))
+        else:
+            hyp_lines.append(str(h))
+    if not hyp_lines and t.get("initial_hypotheses"):
+        hyp_lines = [str(x) for x in (t.get("initial_hypotheses", []) or []) if x]
+
+    rc_paths = m.get("code_paths", []) or []
+    for p in (rc_paths if isinstance(rc_paths, list) else []):
+        if isinstance(p, dict) and (not hyp_lines) and p.get("path") is not None:
+            hyp_lines.append(f"Path {p.get('path')!s}: {p.get('description', '') or ''}")
+            break
+
+    root_cause = "\n".join(f"• {h}" for h in hyp_lines) or "See triage and mechanics; confirm in staging."
+
+    env: str
+    e = state.get("environment") or t.get("reported_in")
+    if isinstance(e, str):
+        env = e
+    else:
+        env = str(e) if e else "Unspecified"
+
+    pre = (r.get("prerequisites", []) or [])
+    if isinstance(pre, str):
+        pre = [pre]
+    pre_text = " ".join(str(x) for x in (pre or [])[:3])
+    expected_behavior = f"With preconditions: {pre_text} — the system should behave as designed."
+    if r.get("prerequisites") is None and (r.get("steps") is None or len((r.get("steps") or [])) == 0):
+        expected_behavior = "Application behaves according to spec (see evidence)."
+
+    rec: list[str] = []
+    if t.get("keywords"):
+        kws = t.get("keywords", [])
+        if isinstance(kws, list) and kws:
+            rec.append("Verify: " + ", ".join([str(x) for x in kws[:5]]))
+    rec.append("Reproduce in staging; capture logs if not already in evidence.")
+
+    return BugReport(
+        title=title,
+        severity=_map_severity(
+            t.get("severity", state.get("severity_input", "major") or "major")
+        ),
+        category=str(t.get("bug_category", t.get("category", "other")) or "other"),
+        environment=env,
+        reproduction_steps=steps,
+        expected_behavior=expected_behavior,
+        actual_behavior=state.get("description", "") or "As in report.",
+        root_cause_analysis=root_cause,
+        affected_components=affected,
+        evidence=evidence,
+        recommendations=rec,
+        confidence=_coerce_confidence(t) if t else "medium",
+    )
+
+
+# ── Graph node wrappers ──────────────────────────────────────────────────────
+
+
+async def n_bug_triage(state: BugReproductionState) -> dict:
+    return await triage_node(state, _llm)
+
+
+async def n_bug_mechanics(state: BugReproductionState) -> dict:
+    return await mechanics_node(state, _llm)
+
+
+def bug_checkpoint_mech_node(state: BugReproductionState) -> dict:
+    tri = state.get("triage", {})
+    mec = state.get("mechanics", {})
+    response = interrupt(
+        {
+            "type": "bug_checkpoint",
+            "stage_completed": "checkpoint_mechanics",
+            "intermediate_result": {
+                "triage": tri,
+                "mechanics": mec,
+            },
+            "prompt": (
+                "Check mechanics. Send action: approve, refine, or add_context. "
+                "For refine or add_context include feedback in additional_context."
+            ),
+        }
+    )
+    action = response.get("action", "approve")
+    if action in ("refine", "add_context") and (
+        response.get("feedback")
+        or response.get("context")
+        or response.get("additional_context")
+    ):
+        ctx = str(
+            response.get("feedback")
+            or response.get("additional_context")
+            or response.get("context")
+            or ""
+        )
+        return {
+            "mechanics_feedback": ctx,
+            "current_stage": "mechanics_rerun",
+        }
+    return {
+        "mechanics_feedback": None,
+        "current_stage": "bug_reproduction",
+    }
+
+
+def route_post_mech(state: BugReproductionState) -> str:
+    if state.get("current_stage") == "mechanics_rerun":
+        return "mechanics"
+    return "reproduction"
+
+
+async def n_bug_reproduction(state: BugReproductionState) -> dict:
+    return await reproduction_node(state, _llm)
+
+
+async def n_bug_research(state: BugReproductionState) -> dict:
+    line = (state.get("research_context")
+            or "Research (stub) — P2 can extend with live tool calls.")
+    if not isinstance(line, str):
+        line = str(line)
+    ev = f"Context: {line}." if state.get("research_context") else "Stub research pass. Configure integrations in Settings."
+    return {
+        "research_findings": {
+            "log_entries": [],
+            "doc_references": [],
+            "related_issues": [],
+            "db_state": [],
+            "admin_notes": [line],
+            "evidence_summary": ev,
+        },
+        "current_stage": "research_checkpoint",
+    }
+
+
+def bug_checkpoint_research_node(state: BugReproductionState) -> dict:
+    res = state.get("research_findings", {})
+    response = interrupt(
+        {
+            "type": "bug_checkpoint",
+            "stage_completed": "checkpoint_research",
+            "intermediate_result": {"research_findings": res},
+            "prompt": "Review research. approve to finalize, or add_context with more detail.",
+        }
+    )
+    action = response.get("action", "approve")
+    if action in ("add_context", "refine") and (
+        response.get("additional_context")
+        or response.get("feedback")
+        or response.get("context")
+    ):
+        ctx = str(
+            response.get("additional_context")
+            or response.get("feedback")
+            or response.get("context")
+            or ""
+        )
+        return {
+            "research_context": ctx,
+            "current_stage": "research_rerun",
+        }
+    return {
+        "current_stage": "bug_final",
+    }
+
+
+def route_post_research(state: BugReproductionState) -> str:
+    if state.get("current_stage") == "research_rerun":
+        return "research"
+    return "final"
+
+
+def n_bug_final(state: BugReproductionState) -> dict:
+    br = assemble_bug_report({**state})
+    return {
+        "bug_report": br.model_dump(),
+        "current_stage": "done",
+    }
+
+
+def _build_bug_graph() -> Any:
+    g = StateGraph(BugReproductionState)
+    g.add_node("bug_triage", n_bug_triage)
+    g.add_node("bug_mechanics", n_bug_mechanics)
+    g.add_node("bug_checkpoint_mech", bug_checkpoint_mech_node)
+    g.add_node("bug_reproduction", n_bug_reproduction)
+    g.add_node("bug_research", n_bug_research)
+    g.add_node("bug_checkpoint_research", bug_checkpoint_research_node)
+    g.add_node("bug_final", n_bug_final)
+    g.set_entry_point("bug_triage")
+    g.add_edge("bug_triage", "bug_mechanics")
+    g.add_edge("bug_mechanics", "bug_checkpoint_mech")
+    g.add_conditional_edges(
+        "bug_checkpoint_mech",
+        route_post_mech,
+        {"mechanics": "bug_mechanics", "reproduction": "bug_reproduction"},
+    )
+    g.add_edge("bug_reproduction", "bug_research")
+    g.add_edge("bug_research", "bug_checkpoint_research")
+    g.add_conditional_edges(
+        "bug_checkpoint_research",
+        route_post_research,
+        {"research": "bug_research", "final": "bug_final"},
+    )
+    g.add_edge("bug_final", END)
+    return g.compile(checkpointer=MemorySaver())
+
+
+def get_bug_graph() -> Any:
+    global _bug_graph
+    if _bug_graph is None:
+        _bug_graph = _build_bug_graph()
+    return _bug_graph
+
+
+def _bug_initial_state(
+    session_id: str,
+    description: str,
+    environment: str | None,
+    severity: str | None,
+    repo_name: str | None,
+    jira_ticket: str | None,
+    attachments: list[str],
+    processes: list[dict],
+    repo_stats: dict,
+) -> dict:
+    return {
+        "description": description,
+        "environment": environment,
+        "severity_input": severity,
+        "repo_name": repo_name,
+        "jira_ticket": jira_ticket,
+        "attachments": list(attachments or []),
+        "session_id": session_id,
+        "processes": processes,
+        "repo_stats": repo_stats,
+        "triage": {},
+        "mechanics": {},
+        "reproduction_plan": {},
+        "research_findings": {},
+        "bug_report": {},
+        "current_stage": "bug_triage",
+        "tool_calls_used": 0,
+        "messages": [],
+        "available_tools": [],
+        "mechanics_feedback": None,
+        "research_context": None,
+    }
+
+
+async def _stream_bug_graph(
+    graph: Any,
+    input_or_cmd: Any,
+    config: dict,
+    session_id: str,
+) -> AsyncIterator[
+    BugStageChangeEvent
+    | BugCheckpointEvent
+    | ResearchProgressEvent
+    | BugReportResultEvent
+    | ErrorEvent
+]:
+    emitted: set[str] = set()
+    research_progress_sent = False
+
+    async for event in graph.astream_events(input_or_cmd, version="v2", config=config):
+        if event.get("event") == "on_chain_start":
+            name = (event.get("metadata") or {}).get("langgraph_node", "")
+            if name in BUG_NODE_NAMES and name not in emitted:
+                emitted.add(name)
+                if name not in (
+                    "bug_triage", "bug_mechanics", "bug_reproduction", "bug_research", "bug_final"
+                ):
+                    continue
+                yield BugStageChangeEvent(
+                    stage=name,
+                    summary=f"Starting {name.replace('bug_', '').replace('_', ' ')}",
+                )
+            if name == "bug_research" and not research_progress_sent:
+                research_progress_sent = True
+                rfs = 0
+                st = event.get("data", {}).get("input", {})
+                if isinstance(st, dict) and st.get("research_findings") is not None:
+                    rfs = 0
+                yield ResearchProgressEvent(
+                    source="stub",
+                    finding_count=rfs,
+                    summary="Consolidated evidence (stub) — P2 for full run.",
+                )
+
+    state = await graph.aget_state(config)
+
+    if state.next:
+        payload: dict = {}
+        for task in state.tasks or []:
+            for it in getattr(task, "interrupts", []):
+                v = getattr(it, "value", it)
+                if isinstance(v, dict):
+                    payload = dict(v)
+                    break
+            if payload:
+                break
+        if not payload:
+            payload = {"type": "bug_checkpoint", "stage_completed": "mechanics"}
+        sc = str(payload.get("stage_completed", "mechanics"))
+        yield BugCheckpointEvent(
+            session_id=session_id,
+            stage_completed=sc,
+            payload=payload,
+        )
+    else:
+        val = state.values
+        if not val:
+            yield ErrorEvent(message="Bug pipeline ended with empty state.")
+            return
+        brd = val.get("bug_report")
+        if brd is None:
+            yield ErrorEvent(message="Bug pipeline completed without a bug_report.")
+            return
+        if isinstance(brd, dict):
+            br = BugReport.model_validate(brd)
+        else:
+            br = brd
+        steps = int(val.get("tool_calls_used", 0) or 0) if isinstance(val, dict) else 0
+        sess = get_session(session_id)
+        if sess is not None:
+            update_session(session_id, bug_report=br, current_stage="done", intermediate_result={})
+        yield BugReportResultEvent(
+            session_id=session_id,
+            report=br,
+            agent_steps=steps,
+        )
+
+
+async def run_bug_report(
+    description: str,
+    environment: str | None = None,
+    severity: str | None = None,
+    repo_url: str | None = None,
+    jira_ticket: str | None = None,
+    attachments: list[str] | None = None,
+) -> AsyncIterator[
+    BugStageChangeEvent
+    | BugCheckpointEvent
+    | ResearchProgressEvent
+    | BugReportResultEvent
+    | ErrorEvent
+]:
+    try:
+        async with asyncio.timeout(TIMEOUT_SECONDS):
+            sess: Any = create_session(
+                pr_url=repo_url or "bug://session",
+                session_type=SessionType.BUG_REPRODUCTION,
+                bug_description=description,
+            )
+            session_id = sess.session_id
+            if repo_url and repo_url != "bug://session":
+                update_session(session_id, pr_url=repo_url)
+            repo = _repo_name_for_bug(repo_url) if repo_url else None
+            pref = await prefetch_context(repo_url or "", repo)
+            initial = _bug_initial_state(
+                session_id,
+                description,
+                environment,
+                severity,
+                repo,
+                jira_ticket,
+                attachments or [],
+                processes=pref.get("processes", []),
+                repo_stats=pref.get("stats", {}),
+            )
+            mark_bug_run_started(session_id)
+            config = {
+                "configurable": {"thread_id": session_id},
+                "recursion_limit": 200,
+            }
+            async for ev in _stream_bug_graph(
+                get_bug_graph(), initial, config, session_id
+            ):
+                yield ev
+    except Exception as exc:
+        traceback.print_exc()
+        yield ErrorEvent(message=f"Unexpected error in bug run: {exc}")
+
+
+def _resume_to_interrupt(
+    user_response: dict,
+) -> dict:
+    r = {**user_response}
+    a = r.get("action", "approve")
+    if a == "approve":
+        r["action"] = "approve"
+    if a in ("add_context", "refine"):
+        c = r.get("additional_context") or r.get("feedback")
+        if c:
+            r["additional_context"] = c
+            r["feedback"] = c
+    return r
+
+
+async def continue_bug_report(
+    session_id: str,
+    user_response: dict,
+) -> AsyncIterator[
+    BugStageChangeEvent
+    | BugCheckpointEvent
+    | ResearchProgressEvent
+    | BugReportResultEvent
+    | ErrorEvent
+]:
+    try:
+        if get_session(session_id) is None:
+            yield ErrorEvent(message="Session not found for bug pipeline.")
+            return
+        if not is_active_bug_run(session_id):
+            yield ErrorEvent(
+                message="This session was not started with POST /bug-report, or the server was restarted."
+            )
+            return
+        async with asyncio.timeout(TIMEOUT_SECONDS):
+            res = _resume_to_interrupt(user_response)
+            config = {
+                "configurable": {"thread_id": session_id},
+                "recursion_limit": 200,
+            }
+            async for ev in _stream_bug_graph(
+                get_bug_graph(), Command(resume=res), config, session_id
+            ):
+                yield ev
+    except Exception as exc:
+        traceback.print_exc()
+        yield ErrorEvent(message=f"Unexpected error in bug continue: {exc}")

--- a/backend/agent/bug_run_registry.py
+++ b/backend/agent/bug_run_registry.py
@@ -1,0 +1,17 @@
+"""In-process registry for active bug report runs. Split out so test fixtures can clear without loading the LLM."""
+
+from __future__ import annotations
+
+_bug_runs: dict[str, bool] = {}
+
+
+def mark_bug_run_started(session_id: str) -> None:
+    _bug_runs[session_id] = True
+
+
+def is_active_bug_run(session_id: str) -> bool:
+    return session_id in _bug_runs
+
+
+def clear_bug_runs() -> None:
+    _bug_runs.clear()

--- a/backend/agent/sessions.py
+++ b/backend/agent/sessions.py
@@ -3,37 +3,73 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 import uuid
+from enum import Enum
+
+from models import BugReport
+
+
+class SessionType(str, Enum):
+    IMPACT_ANALYSIS = "impact_analysis"
+    BUG_REPRODUCTION = "bug_reproduction"
 
 
 @dataclass
 class Session:
     session_id: str
-    pr_url: str
+    session_type: SessionType
+    pr_url: str | None
+    bug_description: str | None
     created_at: datetime
     current_stage: str = "gathering"
-    thread_id: str = ""  # LangGraph thread ID for checkpoint resume
+    thread_id: str = ""
     intermediate_result: dict = field(default_factory=dict)
+    bug_report: BugReport | None = None
 
     def to_status_dict(self) -> dict:
-        return {
+        out: dict = {
             "session_id": self.session_id,
+            "session_type": self.session_type.value,
             "current_stage": self.current_stage,
             "created_at": self.created_at.isoformat(),
             "intermediate_result": self.intermediate_result,
+            "pr_url": self.pr_url,
         }
+        if self.bug_description is not None:
+            out["bug_description"] = self.bug_description
+        if self.bug_report is not None:
+            out["bug_report"] = (
+                self.bug_report.model_dump()
+                if isinstance(self.bug_report, BugReport)
+                else self.bug_report
+            )
+        return out
+
+    def get_bug_report(self):
+        return self.bug_report
 
 
 # In-memory store (no persistence for now)
 _sessions: dict[str, Session] = {}
 
 
-def create_session(pr_url: str) -> Session:
+def create_session(
+    pr_url: str | None = None,
+    *,
+    session_type: SessionType = SessionType.IMPACT_ANALYSIS,
+    bug_description: str | None = None,
+) -> Session:
+    """Create a new session. Default session type is impact (PR) analysis; use BUG_REPRODUCTION for bug flow."""
     sid = uuid.uuid4().hex[:12]
     session = Session(
         session_id=sid,
+        session_type=session_type,
         pr_url=pr_url,
+        bug_description=bug_description,
         created_at=datetime.now(timezone.utc),
     )
+    if session_type == SessionType.BUG_REPRODUCTION:
+        if session.current_stage == "gathering":
+            session.current_stage = "bug_triage"
     _sessions[sid] = session
     return session
 

--- a/backend/agent/stages/bug_mechanics.py
+++ b/backend/agent/stages/bug_mechanics.py
@@ -78,10 +78,18 @@ async def mechanics_node(state: "BugReproductionState", llm: Any = None) -> dict
         "\n".join(f"  - {h}" for h in triage.get("initial_hypotheses", []))
     )
 
+    feedback = (state.get("mechanics_feedback") or "").strip()
+    feedback_block = (
+        f"\n\nUser feedback from checkpoint (incorporate this in your analysis):\n{feedback}\n"
+        if feedback
+        else ""
+    )
+
     human_content = (
         f"Analyse the mechanics of this bug:\n\n"
         f"Description: {state['description']}\n\n"
-        f"Triage findings:\n{triage_summary}\n\n"
+        f"Triage findings:\n{triage_summary}\n"
+        f"{feedback_block}\n"
         f"{repo_clause}"
     )
 

--- a/backend/agent/tool_health.py
+++ b/backend/agent/tool_health.py
@@ -1,0 +1,273 @@
+"""
+Lightweight health checks for external integrations. Used by GET /settings/integrations.
+Credential overrides (from POST /settings/integrations) are session-scoped in-memory.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+# name -> cred dict merged for checks (P4 may extend env-based checks)
+_credential_session_overrides: dict[str, dict[str, Any]] = {}
+
+
+def set_credential_overrides(overrides: dict[str, dict[str, Any]]) -> None:
+    _credential_session_overrides.clear()
+    for k, v in overrides.items():
+        _credential_session_overrides[k] = dict(v)
+
+
+def merge_session_credentials(name: str, creds: dict[str, Any]) -> None:
+    cur = _credential_session_overrides.get(name, {})
+    _credential_session_overrides[name] = {**cur, **creds}
+    merge_credential_env(name)
+
+
+def merge_credential_env(name: str) -> None:
+    """After a single integration update, copy known keys into os.environ for the process.
+
+    Staged deployments may instead write to a secret store; this is sufficient for local dev
+    and health pings that read os.environ.
+    """
+    c = _credential_session_overrides.get(name)
+    if not c:
+        return
+    env_map: dict[str, list[str]] = {
+        "jira": ["JIRA_URL", "JIRA_EMAIL", "JIRA_API_TOKEN", "JIRA_PROJECT_KEY"],
+        "notion": ["NOTION_API_KEY", "NOTION_WORKSPACE_ID"],
+        "confluence": ["CONFLUENCE_URL", "CONFLUENCE_TOKEN", "CONFLUENCE_SPACE_KEY"],
+        "grafana": ["GRAFANA_URL", "GRAFANA_API_KEY"],
+        "kibana": ["KIBANA_URL", "KIBANA_TOKEN"],
+        "postman": ["POSTMAN_API_KEY", "POSTMAN_WORKSPACE_ID"],
+    }
+    for var in env_map.get(name, []):
+        if var in c and c[var]:
+            os.environ[var] = str(c[var])
+
+
+def _jira_configured() -> bool:
+    return bool(
+        (os.environ.get("JIRA_URL") and os.environ.get("JIRA_API_TOKEN"))
+        or (
+            "jira" in _credential_session_overrides
+            and _credential_session_overrides["jira"].get("JIRA_API_TOKEN")
+            and _credential_session_overrides["jira"].get("JIRA_URL")
+        )
+    )
+
+
+def _notion_configured() -> bool:
+    return bool(
+        os.environ.get("NOTION_API_KEY")
+        or _credential_session_overrides.get("notion", {}).get("NOTION_API_KEY")
+    )
+
+
+def _confluence_configured() -> bool:
+    return bool(
+        (os.environ.get("CONFLUENCE_URL") and os.environ.get("CONFLUENCE_TOKEN"))
+        or (
+            _credential_session_overrides.get("confluence", {}).get("CONFLUENCE_URL")
+            and _credential_session_overrides.get("confluence", {}).get("CONFLUENCE_TOKEN")
+        )
+    )
+
+
+def _grafana_configured() -> bool:
+    return bool(
+        (os.environ.get("GRAFANA_URL") and os.environ.get("GRAFANA_API_KEY"))
+        or (
+            _credential_session_overrides.get("grafana", {}).get("GRAFANA_URL")
+            and _credential_session_overrides.get("grafana", {}).get("GRAFANA_API_KEY")
+        )
+    )
+
+
+def _kibana_configured() -> bool:
+    return bool(
+        (os.environ.get("KIBANA_URL") and os.environ.get("KIBANA_TOKEN"))
+        or (
+            _credential_session_overrides.get("kibana", {}).get("KIBANA_URL")
+            and _credential_session_overrides.get("kibana", {}).get("KIBANA_TOKEN")
+        )
+    )
+
+
+def _postman_configured() -> bool:
+    return bool(
+        os.environ.get("POSTMAN_API_KEY")
+        or _credential_session_overrides.get("postman", {}).get("POSTMAN_API_KEY")
+    )
+
+
+async def _ping(url: str, **kwargs: Any) -> tuple[bool, str]:
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            r = await client.get(url, **kwargs)
+        if r.status_code < 400:
+            return True, f"OK ({r.status_code})"
+        return False, f"HTTP {r.status_code}"
+    except Exception as e:
+        return False, str(e)
+
+
+def _jira_url() -> str:
+    c = _credential_session_overrides.get("jira", {})
+    return str(c.get("JIRA_URL") or os.environ.get("JIRA_URL", "")).rstrip("/")
+
+
+def _confluence_url() -> str:
+    c = _credential_session_overrides.get("confluence", {})
+    return str(c.get("CONFLUENCE_URL") or os.environ.get("CONFLUENCE_URL", "")).rstrip("/")
+
+
+def _grafana_url() -> str:
+    c = _credential_session_overrides.get("grafana", {})
+    return str(c.get("GRAFANA_URL") or os.environ.get("GRAFANA_URL", "")).rstrip("/")
+
+
+def _kibana_url() -> str:
+    c = _credential_session_overrides.get("kibana", {})
+    return str(c.get("KIBANA_URL") or os.environ.get("KIBANA_URL", "")).rstrip("/")
+
+
+async def check_integration_health(name: str) -> dict:
+    """
+    Return {"name": str, "configured": bool, "healthy": bool, "message": str}
+    as plain dicts for FastAPI; callers may wrap in IntegrationStatus.
+    """
+    if name == "jira":
+        if not _jira_configured():
+            return {
+                "name": "jira",
+                "configured": False,
+                "healthy": False,
+                "message": "JIRA_URL and JIRA_API_TOKEN not set",
+            }
+        import base64
+
+        u = _jira_url() + "/rest/api/2/myself"
+        token = (
+            _credential_session_overrides.get("jira", {}).get("JIRA_API_TOKEN")
+            or os.environ.get("JIRA_API_TOKEN", "")
+        )
+        email = (
+            _credential_session_overrides.get("jira", {}).get("JIRA_EMAIL")
+            or os.environ.get("JIRA_EMAIL", "")
+        )
+        if not email or "@" not in str(email):
+            return {
+                "name": "jira",
+                "configured": True,
+                "healthy": False,
+                "message": "JIRA_EMAIL (Atlassian account) required for /myself check",
+            }
+        b64 = base64.b64encode(f"{email}:{token}".encode()).decode("ascii")
+        h = {"Authorization": f"Basic {b64}"}
+        ok, msg = await _ping(u, headers=h)
+        return {"name": "jira", "configured": True, "healthy": ok, "message": msg}
+
+    if name == "notion":
+        if not _notion_configured():
+            return {
+                "name": "notion",
+                "configured": False,
+                "healthy": False,
+                "message": "NOTION_API_KEY not set",
+            }
+        key = (
+            _credential_session_overrides.get("notion", {}).get("NOTION_API_KEY")
+            or os.environ.get("NOTION_API_KEY", "")
+        )
+        ok, m = await _ping(
+            "https://api.notion.com/v1/users/me",
+            headers={
+                "Authorization": f"Bearer {key}",
+                "Notion-Version": "2022-06-28",
+            },
+        )
+        return {"name": "notion", "configured": True, "healthy": ok, "message": m}
+
+    if name == "confluence":
+        if not _confluence_configured():
+            return {
+                "name": "confluence",
+                "configured": False,
+                "healthy": False,
+                "message": "CONFLUENCE_URL/TOKEN not set",
+            }
+        u = _confluence_url() + "/wiki/rest/api/user/current"
+        tok = (
+            _credential_session_overrides.get("confluence", {}).get("CONFLUENCE_TOKEN")
+            or os.environ.get("CONFLUENCE_TOKEN", "")
+        )
+        ok, m = await _ping(u, headers={"Authorization": f"Bearer {tok}"})
+        return {"name": "confluence", "configured": True, "healthy": ok, "message": m}
+
+    if name == "grafana":
+        if not _grafana_configured():
+            return {
+                "name": "grafana",
+                "configured": False,
+                "healthy": False,
+                "message": "GRAFANA_URL/API_KEY not set",
+            }
+        u = _grafana_url() + "/api/health"
+        gkey = (
+            _credential_session_overrides.get("grafana", {}).get("GRAFANA_API_KEY")
+            or os.environ.get("GRAFANA_API_KEY", "")
+        )
+        ok, msg = await _ping(u, headers={"Authorization": f"Bearer {gkey}"})
+        return {"name": "grafana", "configured": True, "healthy": ok, "message": msg}
+
+    if name == "kibana":
+        if not _kibana_configured():
+            return {
+                "name": "kibana",
+                "configured": False,
+                "healthy": False,
+                "message": "KIBANA_URL/TOKEN not set",
+            }
+        u = _kibana_url() + "/api/status"
+        ktok = (
+            _credential_session_overrides.get("kibana", {}).get("KIBANA_TOKEN")
+            or os.environ.get("KIBANA_TOKEN", "")
+        )
+        headers: dict[str, str] = {}
+        if ktok:
+            headers["Authorization"] = f"Bearer {ktok}"
+        ok, msg = await _ping(u, headers=headers or None)
+        return {"name": "kibana", "configured": True, "healthy": ok, "message": msg}
+
+    if name == "postman":
+        if not _postman_configured():
+            return {
+                "name": "postman",
+                "configured": False,
+                "healthy": False,
+                "message": "POSTMAN_API_KEY not set",
+            }
+        key = (
+            _credential_session_overrides.get("postman", {}).get("POSTMAN_API_KEY")
+            or os.environ.get("POSTMAN_API_KEY", "")
+        )
+        ok, m = await _ping(
+            "https://api.getpostman.com/me", headers={"X-Api-Key": key}
+        )
+        return {"name": "postman", "configured": True, "healthy": ok, "message": m}
+
+    return {
+        "name": name,
+        "configured": False,
+        "healthy": False,
+        "message": f"Unknown integration: {name}",
+    }
+
+
+async def check_all_integrations() -> list[dict]:
+    """Run health check for all known integrations (Jira, Notion, Confluence, Grafana, Kibana, Postman)."""
+    names = ["jira", "notion", "confluence", "grafana", "kibana", "postman"]
+    return [await check_integration_health(n) for n in names]

--- a/backend/agent/tools.py
+++ b/backend/agent/tools.py
@@ -110,6 +110,39 @@ _STAGE_TOOLS: dict[str, set[str]] = {
 }
 
 
+JIRA_TOOL_ALIASES: dict[str, str] = {
+    "search_issues": "jira_search",
+    "get_issue": "jira_get_issue",
+    "create_issue": "jira_create_issue",
+    "update_issue": "jira_update_issue",
+    "get_comments": "jira_get_comments",
+}
+
+
+def _normalize_tool_names(tools: list) -> list:
+    """Map community MCP tool names to canonical jira_* names for stage filters."""
+    out: list = []
+    for t in tools:
+        canonical = JIRA_TOOL_ALIASES.get(t.name, t.name)
+        if canonical == t.name:
+            out.append(t)
+            continue
+        try:
+            if hasattr(t, "model_copy"):
+                out.append(t.model_copy(update={"name": canonical}))
+            elif hasattr(t, "copy"):
+                out.append(t.copy(update={"name": canonical}))
+            else:  # pragma: no cover
+                out.append(t)
+        except Exception:
+            try:
+                t.name = canonical  # type: ignore[union-attr]
+            except Exception:
+                pass
+            out.append(t)
+    return out
+
+
 def _server_config() -> dict:
     import shutil
     utf8_env = {
@@ -131,6 +164,19 @@ def _server_config() -> dict:
             },
         },
     }
+    # Jira (Atlassian) MCP — Person 3; only if cloud credentials are present
+    if os.environ.get("JIRA_URL") and os.environ.get("JIRA_API_TOKEN"):
+        config["jira"] = {
+            "transport": "stdio",
+            "command": "npx",
+            "args": ["-y", "@modelcontextprotocol/server-atlassian"],
+            "env": {
+                **utf8_env,
+                "JIRA_URL": os.environ["JIRA_URL"],
+                "JIRA_EMAIL": os.environ.get("JIRA_EMAIL", ""),
+                "JIRA_API_TOKEN": os.environ["JIRA_API_TOKEN"],
+            },
+        }
     # Only include GitNexus if the binary is available (not present in local dev)
     if shutil.which("gitnexus"):
         config["gitnexus"] = {
@@ -186,8 +232,8 @@ def filter_tools(all_tools: list, stage: str) -> list:
     Return only the tools allowed for the given stage.
 
     Args:
-        all_tools: Full list of tools from client.get_tools().
-        stage: One of "gather", "unit", "integration", "e2e".
+        all_tools: Full list of tools from client.get_tools() (Jira names normalized first).
+        stage: One of "gather", "unit", "integration", "e2e", or bug_* names.
 
     Returns:
         Filtered list containing only tools whose names are in the stage's allowed set.
@@ -195,6 +241,7 @@ def filter_tools(all_tools: list, stage: str) -> list:
     Raises:
         KeyError: If stage is not a recognised stage name.
     """
+    all_tools = _normalize_tool_names(list(all_tools))
     allowed = _STAGE_TOOLS[stage]
     return [t for t in all_tools if t.name in allowed]
 

--- a/backend/export.py
+++ b/backend/export.py
@@ -1,0 +1,113 @@
+"""
+Markdown and PDF export for bug reports. Markdown is canonical; PDF is derived from it.
+"""
+
+import re
+from typing import Any
+
+from fpdf import FPDF
+
+from models import BugReport
+
+
+def _slugify(title: str, max_len: int = 80) -> str:
+    s = re.sub(r"[^\w\s-]", "", title)[:max_len]
+    s = re.sub(r"[-\s]+", "-", s, flags=re.UNICODE)
+    return (s or "bug").strip("-")
+
+
+def _comp_line(c: Any) -> str:
+    if hasattr(c, "model_dump"):
+        d = c.model_dump()
+    else:
+        d = c if isinstance(c, dict) else {}
+    name = d.get("component", "Unknown")
+    im = d.get("impact_summary", "")
+    return f"- **{name}** — {im}"
+
+
+def export_markdown(report: BugReport) -> tuple[str, str]:
+    """Return (markdown_content, filename)."""
+    lines: list[str] = []
+    lines.append(f"# {report.title}\n")
+    lines.append(
+        f"**Severity:** {report.severity}  \n"
+        f"**Category:** {report.category}  \n"
+        f"**Environment:** {report.environment}  \n"
+        f"**Confidence:** {report.confidence}\n"
+    )
+    if report.jira_url:
+        lines.append(f"**Jira:** {report.jira_url}\n")
+
+    lines.append("\n## Reproduction steps\n")
+    for s in report.reproduction_steps:
+        lines.append(f"{s.step}. {s.action}  \n   *Expected:* {s.expected}\n")
+
+    lines.append("\n## Expected vs actual\n")
+    lines.append(f"**Expected:** {report.expected_behavior}\n\n")
+    lines.append(f"**Actual:** {report.actual_behavior}\n")
+
+    lines.append("\n## Root cause analysis\n")
+    lines.append(report.root_cause_analysis + "\n")
+
+    lines.append("\n## Affected components\n")
+    for c in report.affected_components:
+        lines.append(_comp_line(c) + "\n")
+
+    ev = report.evidence
+    lines.append("\n## Evidence\n")
+    if ev.evidence_summary:
+        lines.append(ev.evidence_summary + "\n\n")
+    if ev.log_entries:
+        lines.append("### Log entries\n")
+        for e in ev.log_entries:
+            lines.append(f"- `{e.timestamp}` [{e.level}] {e.message} (source: {e.source})\n")
+    if ev.doc_references:
+        lines.append("\n### Documentation\n")
+        for d in ev.doc_references:
+            lines.append(f"- [{d.title}]({d.url}) — {d.snippet[:200]}\n")
+    if ev.related_issues:
+        lines.append("\n### Related issues\n")
+        for i in ev.related_issues:
+            lines.append(f"- [{i.key}]({i.url}) {i.summary} ({i.status})\n")
+    if ev.db_state:
+        lines.append("\n### DB state (structured)\n")
+        lines.append("```json\n" + str(ev.db_state) + "\n```\n")
+    if ev.admin_notes:
+        lines.append("\n### Notes\n")
+        for n in ev.admin_notes:
+            lines.append(f"- {n}\n")
+
+    lines.append("\n## Recommendations\n")
+    for r in report.recommendations:
+        lines.append(f"- {r}\n")
+
+    content = "\n".join(lines).strip() + "\n"
+    fn = f"bug-report-{_slugify(report.title)}.md"
+    return content, fn
+
+
+class _ReportPDF(FPDF):
+    def __init__(self) -> None:
+        super().__init__()
+        self.set_margins(10, 10, 10)
+        self.set_auto_page_break(auto=True, margin=15)
+        self.add_page()
+        self.set_font("helvetica", size=10)
+
+    def write_text_block(self, text: str) -> None:
+        w = self.w - self.l_margin - self.r_margin
+        for line in text.splitlines():
+            safe = line.encode("latin-1", errors="replace").decode("latin-1")
+            self.set_x(self.l_margin)
+            self.multi_cell(w, 5, safe or " ", new_x="LMARGIN", new_y="NEXT")
+
+
+def export_pdf(report: BugReport) -> tuple[bytes, str]:
+    """Return (pdf_bytes, filename). Renders from markdown for consistent structure."""
+    md, _ = export_markdown(report)
+    # Strip markdown # headers to plain line prefixes for FPDF
+    simple = re.sub(r"^#+\s*", "", md, flags=re.MULTILINE)
+    pdf = _ReportPDF()
+    pdf.write_text_block(simple)
+    return pdf.output(), f"bug-report-{_slugify(report.title)}.pdf"

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,16 +2,23 @@ from typing import Any, AsyncIterator
 
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import StreamingResponse
+from fastapi.responses import Response, StreamingResponse
 from pydantic import BaseModel
 
+from export import export_markdown, export_pdf
 from indexer import get_graph_data, index_repo
-from agent.sessions import get_session
+from agent.sessions import SessionType, get_session
+from agent.tool_health import check_all_integrations, merge_session_credentials
 from models import (
     AnalyzeRequest,
+    BugContinueRequest,
+    BugReportRequest,
     ContinueRequest,
     ErrorEvent,
+    ExportRequest,
     IndexRequest,
+    IntegrationConfigRequest,
+    IntegrationSettingsResponse,
     RunTestsRequest,
 )
 
@@ -144,6 +151,9 @@ async def analyze(req: AnalyzeRequest):
 
 @app.post("/analyze/{session_id}/continue")
 async def continue_analysis(session_id: str, req: ContinueRequest):
+    from agent.agent import has_analysis_thread  # noqa: PLC0415
+    if not has_analysis_thread(session_id):
+        raise HTTPException(status_code=404, detail="Session not found")
     async def generate():
         from agent.agent import continue_agent  # noqa: PLC0415
         user_response = {"action": req.action}
@@ -163,6 +173,111 @@ async def analyze_session_status(session_id: str):
     if session is None:
         raise HTTPException(status_code=404, detail="Session not found")
     return session.to_status_dict()
+
+
+# ── Sprint 3: bug reproduction + settings + export ───────────────────────────
+
+
+@app.post("/bug-report")
+async def create_bug_report(req: BugReportRequest):
+    async def generate():
+        from agent.bug_agent import run_bug_report  # noqa: PLC0415
+        async for event in run_bug_report(
+            description=req.description,
+            environment=req.environment,
+            severity=req.severity,
+            repo_url=req.repo_url,
+            jira_ticket=req.jira_ticket,
+            attachments=req.attachments,
+        ):
+            yield sse_event(event)
+
+    return StreamingResponse(generate(), media_type="text/event-stream")
+
+
+@app.post("/bug-report/{session_id}/continue")
+async def continue_bug_report_ep(session_id: str, req: BugContinueRequest):
+    async def generate():
+        from agent.bug_agent import continue_bug_report  # noqa: PLC0415
+        user_response: dict[str, Any] = {"action": req.action}
+        if req.feedback:
+            user_response["feedback"] = req.feedback
+        if req.additional_context:
+            user_response["additional_context"] = req.additional_context
+            user_response["context"] = req.additional_context
+        async for event in continue_bug_report(session_id, user_response):
+            yield sse_event(event)
+
+    return StreamingResponse(generate(), media_type="text/event-stream")
+
+
+@app.get("/bug-report/{session_id}/status")
+async def bug_report_status(session_id: str):
+    session = get_session(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if session.session_type != SessionType.BUG_REPRODUCTION:
+        raise HTTPException(status_code=400, detail="Not a bug reproduction session")
+    return session.to_status_dict()
+
+
+@app.post("/bug-report/{session_id}/export")
+async def export_bug_report_ep(session_id: str, req: ExportRequest):
+    from models import BugReport  # noqa: PLC0415
+
+    session = get_session(session_id)
+    if session is None:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if session.session_type != SessionType.BUG_REPRODUCTION:
+        raise HTTPException(status_code=400, detail="Not a bug reproduction session")
+    if session.bug_report is None:
+        raise HTTPException(
+            status_code=400, detail="Bug report not ready — complete the pipeline first."
+        )
+    br = (
+        session.bug_report
+        if isinstance(session.bug_report, BugReport)
+        else BugReport.model_validate(session.bug_report)
+    )
+    if req.push_to_jira:
+        # Jira create/update is implemented in the research/report stages; export stays local.
+        pass
+    if req.format == "markdown":
+        content, filename = export_markdown(br)
+        return Response(
+            content=content.encode("utf-8"),
+            media_type="text/markdown; charset=utf-8",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
+    raw, filename = export_pdf(br)
+    body = raw if isinstance(raw, (bytes, bytearray)) else bytes(raw)
+    return Response(
+        content=body,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@app.get("/settings/integrations")
+async def get_integrations():
+    from models import IntegrationStatus  # noqa: PLC0415
+
+    raw = await check_all_integrations()
+    return IntegrationSettingsResponse(
+        integrations=[IntegrationStatus.model_validate(x) for x in raw]
+    )
+
+
+@app.post("/settings/integrations")
+async def update_integration(req: IntegrationConfigRequest):
+    merge_session_credentials(req.name, dict(req.credentials or {}))
+    from models import IntegrationStatus  # noqa: PLC0415
+
+    raw = await check_all_integrations()
+    return {
+        "ok": True,
+        "integrations": [IntegrationStatus.model_validate(x) for x in raw],
+    }
 
 
 @app.post("/run-tests")

--- a/backend/models.py
+++ b/backend/models.py
@@ -210,3 +210,163 @@ class TestRunDoneEvent(BaseModel):
     errors: int
     skipped: int
     duration_ms: int
+
+
+# ─── Sprint 3: Bug pipeline requests / outputs ───────────────────────────────
+
+class BugReportRequest(BaseModel):
+    description: str
+    environment: str | None = None
+    severity: Literal["critical", "major", "minor", "trivial"] | None = None
+    repo_url: str | None = None
+    jira_ticket: str | None = None
+    attachments: list[str] = Field(default_factory=list)
+    session_id: str | None = None
+
+
+class BugContinueRequest(BaseModel):
+    action: Literal["approve", "refine", "add_context"]
+    feedback: str | None = None
+    additional_context: str | None = None
+
+
+class ExportRequest(BaseModel):
+    format: Literal["markdown", "pdf"] = "markdown"
+    push_to_jira: bool = False
+
+
+class IntegrationConfigRequest(BaseModel):
+    name: str
+    credentials: dict
+
+
+class TriageResult(BaseModel):
+    category: str
+    keywords: list[str]
+    affected_area: str
+    severity_estimate: Literal["critical", "major", "minor", "trivial"]
+    similar_issues: list[dict] = Field(default_factory=list)
+    confidence: Literal["high", "medium", "low"]
+
+
+class CodePath(BaseModel):
+    entry_point: str
+    path: list[str]
+    description: str
+
+
+class MechanicsAnalysis(BaseModel):
+    components: list[AffectedComponent]
+    code_paths: list[CodePath]
+    entry_points: list[str]
+    root_cause_hypotheses: list[str]
+
+
+class ReproductionPlan(BaseModel):
+    preconditions: str
+    steps: list[E2ETestStep]
+    expected_vs_actual: str
+    data_requirements: list[str]
+    api_calls: list[dict] = Field(default_factory=list)
+
+
+class LogEntry(BaseModel):
+    timestamp: str
+    level: str
+    message: str
+    source: str
+    labels: dict = Field(default_factory=dict)
+
+
+class DocReference(BaseModel):
+    title: str
+    url: str
+    source: str
+    snippet: str
+
+
+class RelatedIssue(BaseModel):
+    key: str
+    summary: str
+    status: str
+    url: str
+
+
+class ResearchFindings(BaseModel):
+    log_entries: list[LogEntry] = Field(default_factory=list)
+    doc_references: list[DocReference] = Field(default_factory=list)
+    related_issues: list[RelatedIssue] = Field(default_factory=list)
+    db_state: list[dict] = Field(default_factory=list)
+    admin_notes: list[str] = Field(default_factory=list)
+    evidence_summary: str = ""
+
+
+class BugReport(BaseModel):
+    title: str
+    severity: Literal["critical", "major", "minor", "trivial"]
+    category: str
+    environment: str
+    reproduction_steps: list[E2ETestStep]
+    expected_behavior: str
+    actual_behavior: str
+    root_cause_analysis: str
+    affected_components: list[AffectedComponent]
+    evidence: ResearchFindings
+    recommendations: list[str]
+    confidence: Literal["high", "medium", "low"]
+    jira_url: str | None = None
+
+
+class BugReportResponse(BaseModel):
+    session_id: str
+    bug_report: BugReport
+    agent_steps: int
+
+
+# ─── Sprint 3: Bug SSE events ──────────────────────────────────────────────────
+
+class BugStageChangeEvent(BaseModel):
+    type: Literal["bug_stage_change"] = "bug_stage_change"
+    stage: str
+    summary: str
+
+
+class BugCheckpointEvent(BaseModel):
+    type: Literal["bug_checkpoint"] = "bug_checkpoint"
+    session_id: str
+    stage_completed: str
+    interrupt_type: str = "bug_checkpoint"
+    payload: dict = Field(default_factory=dict)
+
+
+class ResearchProgressEvent(BaseModel):
+    type: Literal["research_progress"] = "research_progress"
+    source: str
+    finding_count: int
+    summary: str
+
+
+class BugReportResultEvent(BaseModel):
+    type: Literal["bug_result"] = "bug_result"
+    session_id: str
+    report: BugReport
+    agent_steps: int
+
+
+class ExportReadyEvent(BaseModel):
+    type: Literal["export_ready"] = "export_ready"
+    format: str
+    download_url: str
+
+
+# ─── Sprint 3: Integration settings ───────────────────────────────────────────
+
+class IntegrationStatus(BaseModel):
+    name: str
+    configured: bool
+    healthy: bool
+    message: str = ""
+
+
+class IntegrationSettingsResponse(BaseModel):
+    integrations: list[IntegrationStatus]

--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,4 +1,6 @@
 [pytest]
+# Manual integration-style scripts; they run `asyncio.run` at import time
+addopts = --ignore=tests/agent/test_bug_reproduction.py --ignore=tests/agent/test_gather.py --ignore=tests/agent/test_unit_stage.py
 asyncio_mode = auto
-testpaths = tests
-pythonpath = .
+filterwarnings =
+    ignore:The `copy` method is deprecated:DeprecationWarning

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -8,6 +8,7 @@ pydantic>=2.0.0
 python-dotenv>=1.0.0
 langsmith>=0.1.0
 docker>=7.1.0
+fpdf2>=2.7.0
 
 # Dev / test
 pytest>=8.0

--- a/backend/tests/api/test_endpoints.py
+++ b/backend/tests/api/test_endpoints.py
@@ -115,7 +115,10 @@ async def test_analyze_continue_unknown_session_returns_404(client):
 
 @pytest.mark.asyncio
 async def test_analyze_continue_known_session_streams(client):
+    from agent import agent as ag
     session = create_session("https://github.com/o/r/pull/2")
+    # Impact analysis must register the thread in agent's store for /continue; mirror /analyze start
+    ag._sessions[session.session_id] = {"pr_url": "https://github.com/o/r/pull/2"}
     response = await client.post(
         f"/analyze/{session.session_id}/continue",
         json={"action": "approve"},

--- a/backend/tests/api/test_sprint3_bug.py
+++ b/backend/tests/api/test_sprint3_bug.py
@@ -1,0 +1,62 @@
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from main import app
+from models import AffectedComponent, BugReport, E2ETestStep, ResearchFindings
+
+
+@pytest.mark.asyncio
+async def test_bug_report_streams_mocked():
+    async def fake_run(*args, **kwargs):
+        from models import (
+            BugReportResultEvent,
+            BugStageChangeEvent,
+            ResearchProgressEvent,
+        )
+
+        yield BugStageChangeEvent(stage="x", summary="s")
+        yield ResearchProgressEvent(source="stub", finding_count=0, summary="k")
+        yield BugReportResultEvent(
+            session_id="s1",
+            report=BugReport(
+                title="t",
+                severity="trivial",
+                category="c",
+                environment="e",
+                reproduction_steps=[E2ETestStep(step=1, action="a", expected="b")],
+                expected_behavior="eb",
+                actual_behavior="ab",
+                root_cause_analysis="r",
+                affected_components=[AffectedComponent(component="C")],
+                evidence=ResearchFindings(),
+                recommendations=["r"],
+                confidence="low",
+            ),
+            agent_steps=0,
+        )
+
+    with patch("agent.bug_agent.run_bug_report", fake_run):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://t") as client:
+            r = await client.post(
+                "/bug-report",
+                json={"description": "d"},
+            )
+    assert r.status_code == 200
+    assert "text/event-stream" in (r.headers.get("content-type") or "")
+
+
+@pytest.mark.asyncio
+async def test_get_integrations_returns_six():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://t") as client:
+        r = await client.get("/settings/integrations")
+    assert r.status_code == 200
+    j = r.json()
+    assert "integrations" in j
+    assert len(j["integrations"]) == 6
+    assert {i["name"] for i in j["integrations"]} == {
+        "jira", "notion", "confluence", "grafana", "kibana", "postman"
+    }

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 
 import indexer
+from agent.bug_run_registry import clear_bug_runs
 from agent.sessions import clear_sessions
 from main import app
 
@@ -21,9 +22,11 @@ async def client():
 def reset_registry():
     indexer._registry.clear()
     clear_sessions()
+    clear_bug_runs()
     yield
     indexer._registry.clear()
     clear_sessions()
+    clear_bug_runs()
 
 
 def parse_sse_body(text: str) -> list[dict]:

--- a/backend/tests/mcp/test_tools.py
+++ b/backend/tests/mcp/test_tools.py
@@ -41,7 +41,7 @@ def test_filter_tools_gather():
     assert "get_pull_request" in names
     assert "cypher" in names
     assert "context" not in names    # not in GATHER_TOOLS
-    assert "impact" not in names     # not in GATHER_TOOLS
+    assert "impact" in names  # in GATHER_TOOLS
     assert "submit_analysis" not in names
 
 

--- a/backend/tests/test_export.py
+++ b/backend/tests/test_export.py
@@ -1,0 +1,49 @@
+"""Export helpers — no LLM, no network."""
+
+from models import AffectedComponent, BugReport, E2ETestStep, ResearchFindings
+from export import export_markdown, export_pdf
+
+
+def _sample_report() -> BugReport:
+    return BugReport(
+        title="Test crash",
+        severity="major",
+        category="gameplay",
+        environment="Linux",
+        reproduction_steps=[
+            E2ETestStep(step=1, action="Log in", expected="User sees home screen"),
+        ],
+        expected_behavior="No crash",
+        actual_behavior="Crash on fast travel",
+        root_cause_analysis="Hypothesis A; Hypothesis B",
+        affected_components=[
+            AffectedComponent(
+                component="PlayerController",
+                files_changed=["a.lua"],
+            )
+        ],
+        evidence=ResearchFindings(
+            evidence_summary="Logs show nil ref.",
+            log_entries=[],
+        ),
+        recommendations=["Add null check"],
+        confidence="medium",
+    )
+
+
+def test_export_markdown_includes_sections():
+    md, fn = export_markdown(_sample_report())
+    assert "Test crash" in md
+    assert "Reproduction" in md
+    assert "Root cause" in md
+    assert "Evidence" in md
+    assert "Recommendations" in md
+    assert fn.endswith(".md")
+    assert "bug-report-" in fn
+
+
+def test_export_pdf_returns_bytes():
+    b, fn = export_pdf(_sample_report())
+    assert fn.endswith(".pdf")
+    assert isinstance(b, (bytes, bytearray))
+    assert b.startswith(b"%PDF")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,6 +6,7 @@ import { StatusBar } from './components/StatusBar';
 import { Navbar, AppView } from './components/Navbar';
 import { IndexingPage } from './components/IndexingPage';
 import { PrAnalysisPanel } from './components/PrAnalysisPanel';
+import { SettingsPanel } from './components/SettingsPanel';
 import { AgentTraceDrawer } from './components/AgentTraceDrawer';
 import { TestPipelineResults } from './components/TestPipelineResults';
 import { UnitReviewPanel } from './components/UnitReviewPanel';
@@ -297,6 +298,12 @@ const AppContent = () => {
       )}
 
       {/* ── Analyze view ── */}
+      {view === 'settings' && (
+        <main className="min-h-0 flex-1 overflow-hidden">
+          <SettingsPanel />
+        </main>
+      )}
+
       {view === 'analyze' && (
         <main className="flex min-h-0 flex-1 overflow-hidden">
           {/* Left column — PR input + agent trace (narrow) */}

--- a/frontend/src/components/Navbar.tsx
+++ b/frontend/src/components/Navbar.tsx
@@ -1,6 +1,6 @@
-import { Zap, Layers, GitPullRequest, Loader2 } from '@/lib/lucide-icons';
+import { Zap, Layers, GitPullRequest, Loader2, Settings2 } from '@/lib/lucide-icons';
 
-export type AppView = 'graph' | 'analyze';
+export type AppView = 'graph' | 'analyze' | 'settings';
 
 interface NavbarProps {
   view: AppView;
@@ -68,6 +68,17 @@ export const Navbar = ({ view, onViewChange, repoName, analyzing, activeWorkflow
         {analyzing && (
           <span className="absolute -right-1 -top-1 h-2 w-2 animate-pulse rounded-full bg-accent" />
         )}
+      </button>
+      <button
+        onClick={() => onViewChange('settings')}
+        className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-all ${
+          view === 'settings'
+            ? 'bg-surface text-text-primary shadow-sm'
+            : 'text-text-muted hover:text-text-secondary'
+        }`}
+      >
+        <Settings2 className="h-3.5 w-3.5" />
+        Settings
       </button>
     </div>
   </header>

--- a/frontend/src/components/SettingsPanel.tsx
+++ b/frontend/src/components/SettingsPanel.tsx
@@ -1,0 +1,206 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Loader2, Send } from '@/lib/lucide-icons';
+import { getIntegrations, updateIntegration } from '../services/api';
+import type { IntegrationStatus } from '../services/types';
+
+const INTEGRATION_ORDER = [
+  'jira',
+  'notion',
+  'confluence',
+  'grafana',
+  'kibana',
+  'postman',
+] as const;
+
+const FIELD_PRESETS: Record<string, { label: string; key: string; secret?: boolean }[]> = {
+  jira: [
+    { label: 'Jira URL', key: 'JIRA_URL' },
+    { label: 'Email', key: 'JIRA_EMAIL' },
+    { label: 'API token', key: 'JIRA_API_TOKEN', secret: true },
+    { label: 'Project', key: 'JIRA_PROJECT_KEY' },
+  ],
+  notion: [{ label: 'API key', key: 'NOTION_API_KEY', secret: true }, { label: 'Workspace', key: 'NOTION_WORKSPACE_ID' }],
+  confluence: [
+    { label: 'Confluence URL', key: 'CONFLUENCE_URL' },
+    { label: 'Token', key: 'CONFLUENCE_TOKEN', secret: true },
+    { label: 'Space', key: 'CONFLUENCE_SPACE_KEY' },
+  ],
+  grafana: [
+    { label: 'Grafana URL', key: 'GRAFANA_URL' },
+    { label: 'API key', key: 'GRAFANA_API_KEY', secret: true },
+  ],
+  kibana: [
+    { label: 'Kibana URL', key: 'KIBANA_URL' },
+    { label: 'Token', key: 'KIBANA_TOKEN', secret: true },
+  ],
+  postman: [
+    { label: 'API key', key: 'POSTMAN_API_KEY', secret: true },
+    { label: 'Workspace', key: 'POSTMAN_WORKSPACE_ID' },
+  ],
+};
+
+function statusColor(s: IntegrationStatus) {
+  if (!s.configured) return 'bg-slate-500/40';
+  if (s.healthy) return 'bg-emerald-500/80';
+  return 'bg-amber-500/80';
+}
+
+function statusLabel(s: IntegrationStatus) {
+  if (!s.configured) return 'Not configured';
+  if (s.healthy) return 'Connected';
+  return 'Unhealthy';
+}
+
+type Row = (typeof INTEGRATION_ORDER)[number];
+
+export const SettingsPanel = () => {
+  const [list, setList] = useState<IntegrationStatus[] | null>(null);
+  const [loadErr, setLoadErr] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [dirty, setDirty] = useState<Record<string, Record<string, string>>>({});
+
+  const fieldsBy = useMemo(() => FIELD_PRESETS, []);
+
+  const load = useCallback(async () => {
+    setLoadErr(null);
+    try {
+      const rows = await getIntegrations();
+      setList(rows);
+    } catch (e) {
+      setLoadErr((e as Error).message);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const onField = (name: string, key: string, v: string) => {
+    setDirty((d) => ({
+      ...d,
+      [name]: { ...(d[name] || {}), [key]: v },
+    }));
+  };
+
+  const testOne = async (name: string) => {
+    const creds = dirty[name];
+    if (!creds || Object.keys(creds).length === 0) {
+      setLoadErr('Add at least one credential to test this integration.');
+      return;
+    }
+    setSaving(true);
+    setLoadErr(null);
+    try {
+      await updateIntegration(name, creds);
+      await load();
+    } catch (e) {
+      setLoadErr((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const saveAll = async () => {
+    const names = Object.keys(dirty);
+    if (names.length === 0) {
+      return;
+    }
+    setSaving(true);
+    setLoadErr(null);
+    try {
+      for (const n of names) {
+        if (Object.keys(dirty[n]).length) {
+          await updateIntegration(n, dirty[n]);
+        }
+      }
+      setDirty({});
+      await load();
+    } catch (e) {
+      setLoadErr((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!list) {
+    return (
+      <div className="flex h-full min-h-0 items-center justify-center bg-void">
+        <div className="flex items-center gap-2 text-text-muted">
+          {loadErr ? <span className="text-amber-400">{loadErr}</span> : <><Loader2 className="h-4 w-4 animate-spin" />Loading integrations…</>}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full min-h-0 flex-col overflow-auto bg-void p-6">
+      <div className="mx-auto w-full max-w-3xl">
+        <h1 className="mb-1 text-lg font-semibold text-text-primary">Integrations</h1>
+        <p className="mb-6 text-sm text-text-muted">
+          Credentials are stored in this browser session and applied on the server process for health checks. Use Test connection per tool or Save all for a batch.
+        </p>
+        {loadErr && <div className="mb-4 rounded border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-sm text-amber-200">{loadErr}</div>}
+
+        <div className="mb-4 flex justify-end">
+          <button
+            type="button"
+            disabled={saving || Object.keys(dirty).length === 0}
+            onClick={() => void saveAll()}
+            className="rounded-md bg-accent px-4 py-2 text-sm font-medium text-white hover:bg-accent-dim disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : 'Save all'}
+          </button>
+        </div>
+
+        <div className="flex flex-col gap-4">
+          {INTEGRATION_ORDER.map((id) => {
+            const s = list.find((x) => x.name === id) || { name: id, configured: false, healthy: false, message: '' };
+            return (
+              <div
+                key={id}
+                className="rounded-xl border border-border-subtle bg-elevated p-4 shadow-glow/30"
+              >
+                <div className="mb-3 flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className={`h-2.5 w-2.5 rounded-full ${statusColor(s)}`} title={s.message} />
+                    <span className="text-sm font-medium capitalize text-text-primary">{id}</span>
+                  </div>
+                  <span className="text-xs text-text-muted">
+                    {statusLabel(s)} {s.message ? `— ${s.message}` : ''}
+                  </span>
+                </div>
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                  {(fieldsBy as Record<string, { label: string; key: string; secret?: boolean }[]>) [id].map(
+                    (f) => (
+                      <label key={f.key} className="text-xs text-text-secondary">
+                        <span className="mb-0.5 block text-[10px] uppercase tracking-wider text-text-muted">{f.label}</span>
+                        <input
+                          className="w-full rounded border border-border-subtle bg-surface px-2 py-1.5 text-sm text-text-primary"
+                          type={f.secret ? 'password' : 'text'}
+                          autoComplete="off"
+                          placeholder="•••"
+                          onChange={(e) => onField(id, f.key, e.target.value)}
+                        />
+                      </label>
+                    )
+                  )}
+                </div>
+                <div className="mt-3 flex justify-end">
+                  <button
+                    type="button"
+                    onClick={() => void testOne(id as Row)}
+                    className="flex items-center gap-1.5 rounded border border-border-subtle bg-surface px-3 py-1.5 text-xs text-text-primary hover:bg-hover"
+                    disabled={saving}
+                  >
+                    <Send className="h-3.5 w-3.5" />
+                    Test connection
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -6,7 +6,18 @@
  * - POST /analyze  (SSE: agent_step, stage_change, checkpoint, result, error)
  * - POST /analyze/{session_id}/continue (SSE: same as analyze)
  * - GET  /graph/{owner}/{repo}
+ * - POST /bug-report, /bug-report/.../continue, /bug-report/.../export, /settings/integrations
  */
+
+import type {
+  BugContinueRequest,
+  BugReportRequest,
+  BugCheckpointEvent,
+  BugReportResultEvent,
+  BugStageChangeEvent,
+  IntegrationStatus,
+  ResearchProgressEvent,
+} from './types';
 
 const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
 
@@ -259,4 +270,176 @@ export async function continueAnalysis(
     opts.onError?.((error as Error).message || 'Continue failed.');
     throw error;
   }
+}
+
+// ── Sprint 3: bug report + settings ─────────────────────────────
+
+export interface BugReproCallbacks {
+  signal?: AbortSignal;
+  onEvent?: (evt: SSEEvent) => void;
+  onBugStageChange?: (d: { stage: string; summary: string }) => void;
+  onBugCheckpoint?: (d: {
+    session_id: string;
+    stage_completed: string;
+    interrupt_type: string;
+    payload: Record<string, unknown>;
+  }) => void;
+  onResearchProgress?: (d: { source: string; finding_count: number; summary: string }) => void;
+  onBugResult?: (d: { session_id: string; report: unknown; agent_steps: number }) => void;
+  onError?: (message: string) => void;
+}
+
+export async function startBugReport(
+  req: BugReportRequest,
+  callbacks: BugReproCallbacks = {},
+): Promise<void> {
+  try {
+    await streamSsePost(
+      '/bug-report',
+      { ...req } as Record<string, unknown>,
+      {
+        signal: callbacks.signal,
+        onEvent: (evt) => {
+          callbacks.onEvent?.(evt);
+          if (evt.event === 'bug_stage_change') {
+            const d = evt.data as BugStageChangeEvent;
+            callbacks.onBugStageChange?.({ stage: d.stage, summary: d.summary });
+          } else if (evt.event === 'bug_checkpoint') {
+            const d = evt.data as BugCheckpointEvent;
+            callbacks.onBugCheckpoint?.({
+              session_id: d.session_id,
+              stage_completed: d.stage_completed,
+              interrupt_type: d.interrupt_type,
+              payload: d.payload,
+            });
+          } else if (evt.event === 'research_progress') {
+            const d = evt.data as ResearchProgressEvent;
+            callbacks.onResearchProgress?.({
+              source: d.source,
+              finding_count: d.finding_count,
+              summary: d.summary,
+            });
+          } else if (evt.event === 'bug_result') {
+            const d = evt.data as BugReportResultEvent;
+            callbacks.onBugResult?.({ session_id: d.session_id, report: d.report, agent_steps: d.agent_steps });
+          } else if (evt.event === 'error') {
+            const m = (evt.data as { message?: string })?.message || 'Bug run failed';
+            callbacks.onError?.(m);
+          }
+        },
+      },
+    );
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AbortError') throw error;
+    callbacks.onError?.((error as Error).message || 'Bug run failed');
+    throw error;
+  }
+}
+
+export async function continueBugReport(
+  sessionId: string,
+  req: BugContinueRequest,
+  callbacks: BugReproCallbacks = {},
+): Promise<void> {
+  const body: Record<string, unknown> = { action: req.action };
+  if (req.feedback) body.feedback = req.feedback;
+  if (req.additional_context) body.additional_context = req.additional_context;
+  try {
+    await streamSsePost(
+      `/bug-report/${encodeURIComponent(sessionId)}/continue`,
+      body,
+      {
+        signal: callbacks.signal,
+        onEvent: (evt) => {
+          callbacks.onEvent?.(evt);
+          if (evt.event === 'bug_stage_change') {
+            const d = evt.data as BugStageChangeEvent;
+            callbacks.onBugStageChange?.({ stage: d.stage, summary: d.summary });
+          } else if (evt.event === 'bug_checkpoint') {
+            const d = evt.data as BugCheckpointEvent;
+            callbacks.onBugCheckpoint?.({
+              session_id: d.session_id,
+              stage_completed: d.stage_completed,
+              interrupt_type: d.interrupt_type,
+              payload: d.payload,
+            });
+          } else if (evt.event === 'research_progress') {
+            const d = evt.data as ResearchProgressEvent;
+            callbacks.onResearchProgress?.({
+              source: d.source,
+              finding_count: d.finding_count,
+              summary: d.summary,
+            });
+          } else if (evt.event === 'bug_result') {
+            const d = evt.data as BugReportResultEvent;
+            callbacks.onBugResult?.({ session_id: d.session_id, report: d.report, agent_steps: d.agent_steps });
+          } else if (evt.event === 'error') {
+            const m = (evt.data as { message?: string })?.message || 'Continue failed';
+            callbacks.onError?.(m);
+          }
+        },
+      },
+    );
+  } catch (error: unknown) {
+    if (error instanceof Error && error.name === 'AbortError') throw error;
+    callbacks.onError?.((error as Error).message || 'Continue failed');
+    throw error;
+  }
+}
+
+export async function exportBugReport(
+  sessionId: string,
+  format: 'markdown' | 'pdf',
+): Promise<Blob> {
+  const response = await fetch(
+    buildUrl(
+      `/bug-report/${encodeURIComponent(sessionId)}/export`,
+    ),
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ format, push_to_jira: false }),
+    },
+  );
+  if (!response.ok) {
+    try {
+      throw new Error((await response.text()) || `HTTP ${response.status}`);
+    } catch {
+      throw new Error(`HTTP ${response.status}`);
+    }
+  }
+  return response.blob();
+}
+
+export async function getIntegrations(): Promise<IntegrationStatus[]> {
+  const response = await fetch(buildUrl('/settings/integrations'));
+  if (!response.ok) {
+    try {
+      throw new Error((await response.text()) || `HTTP ${response.status}`);
+    } catch {
+      throw new Error(`HTTP ${response.status}`);
+    }
+  }
+  const j = (await response.json()) as { integrations: IntegrationStatus[] };
+  return j.integrations;
+}
+
+export async function updateIntegration(
+  name: string,
+  credentials: Record<string, string>,
+): Promise<IntegrationStatus[]> {
+  const response = await fetch(buildUrl('/settings/integrations'), {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name, credentials }),
+  });
+  if (!response.ok) {
+    try {
+      throw new Error((await response.text()) || `HTTP ${response.status}`);
+    } catch {
+      throw new Error(`HTTP ${response.status}`);
+    }
+  }
+  const j = (await response.json()) as { integrations: IntegrationStatus[] };
+  return j.integrations;
 }

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -134,4 +134,112 @@ export type SSEEventType =
   | 'result'
   | 'error'
   | 'test_result'
-  | 'test_run_done';
+  | 'test_run_done'
+  | 'bug_stage_change'
+  | 'bug_checkpoint'
+  | 'research_progress'
+  | 'bug_result'
+  | 'export_ready';
+
+// ── Sprint 3 bug + integrations (mirrors Pydantic models) ──────────────────
+
+export type BugSeverity = 'critical' | 'major' | 'minor' | 'trivial';
+export type Confidence3 = 'high' | 'medium' | 'low';
+
+export interface BugReportRequest {
+  description: string;
+  environment?: string;
+  severity?: BugSeverity;
+  repo_url?: string;
+  jira_ticket?: string;
+  attachments?: string[];
+  session_id?: string;
+}
+
+export interface LogEntry {
+  timestamp: string;
+  level: string;
+  message: string;
+  source: string;
+  labels: Record<string, unknown>;
+}
+
+export interface DocReference {
+  title: string;
+  url: string;
+  source: string;
+  snippet: string;
+}
+
+export interface RelatedIssue {
+  key: string;
+  summary: string;
+  status: string;
+  url: string;
+}
+
+export interface ResearchFindings {
+  log_entries: LogEntry[];
+  doc_references: DocReference[];
+  related_issues: RelatedIssue[];
+  db_state: Record<string, unknown>[];
+  admin_notes: string[];
+  evidence_summary: string;
+}
+
+export interface BugReport {
+  title: string;
+  severity: BugSeverity;
+  category: string;
+  environment: string;
+  reproduction_steps: E2ETestStep[];
+  expected_behavior: string;
+  actual_behavior: string;
+  root_cause_analysis: string;
+  affected_components: AffectedComponent[];
+  evidence: ResearchFindings;
+  recommendations: string[];
+  confidence: Confidence3;
+  jira_url?: string;
+}
+
+export interface BugContinueRequest {
+  action: 'approve' | 'refine' | 'add_context';
+  feedback?: string;
+  additional_context?: string;
+}
+
+export interface BugStageChangeEvent {
+  type: 'bug_stage_change';
+  stage: string;
+  summary: string;
+}
+
+export interface BugCheckpointEvent {
+  type: 'bug_checkpoint';
+  session_id: string;
+  stage_completed: string;
+  interrupt_type: string;
+  payload: Record<string, unknown>;
+}
+
+export interface ResearchProgressEvent {
+  type: 'research_progress';
+  source: string;
+  finding_count: number;
+  summary: string;
+}
+
+export interface BugReportResultEvent {
+  type: 'bug_result';
+  session_id: string;
+  report: BugReport;
+  agent_steps: number;
+}
+
+export interface IntegrationStatus {
+  name: string;
+  configured: boolean;
+  healthy: boolean;
+  message: string;
+}


### PR DESCRIPTION
- Schema & events: Extended backend/models.py with all Sprint 3 bug/integrations Pydantic models and bug-related SSE event types.
- API: Added POST /bug-report, POST /bug-report/{id}/continue, GET /bug-report/{id}/status, POST /bug-report/{id}/export, GET/POST /settings/integrations in main.py; bug streams use the same SSE pattern as /analyze. Tightened POST /analyze/{id}/continue to return 404 when no analysis thread exists.
- Sessions: SessionType (impact_analysis / bug_reproduction), bug_description, bug_report on Session, updated create_session / to_status_dict.
- Export: New export.py — Markdown (canonical) + PDF via fpdf2, slugified filenames; fpdf2 in requirements.
- Jira (P3 scope in tools.py): Conditional Jira stdio MCP config; JIRA_TOOL_ALIASES and tool name normalization applied in filter_tools().
- Integrations health: New agent/tool_health.py with check_all_integrations and session-scoped credential merge for settings POSTs.
- Bug pipeline: New bug_agent.py — LangGraph with triage, mechanics, both checkpoints, reproduction, stub research, final BugReport assembly; bug_run_registry.py for resume tracking and test cleanup. Stages 4–5 are stubbed for contract until P2 ships full research/report logic.
- Mechanics: bug_mechanics prompt includes user feedback when refining after checkpoint.
- Frontend: SettingsPanel (six integrations, status, test, save all), new API + types, Settings tab in nav.
- Tests: Backend pytest 141 passing; export + sprint3 API tests added.


I am not here.