### PR TITLE
Que Sera Sera...

### DIFF
--- a/backend/evals/bug_evaluators.py
+++ b/backend/evals/bug_evaluators.py
@@ -9,8 +9,23 @@ Each evaluator returns:
     "details": list of {"check", "passed", "value"} — one entry per check
   }
 
-Person 1 owns: triage_accuracy, mechanics_grounding, reproduction_executability
+Deterministic evaluators (no LLM cost, run always):
+  Person 1 — stages 1-3: triage_accuracy, mechanics_grounding, reproduction_executability
+  Person 2 — stages 4-5: bug_pipeline_health, research_coverage, report_completeness,
+                          report_actionability, evidence_quality, tool_efficiency,
+                          graceful_degradation
+
+LLM-as-judge evaluators (async, require ANTHROPIC_API_KEY):
+  root_cause_quality       — does the report root cause match expected keywords?
+  report_coherence         — is the report specific, internally consistent, grounded?
+  reproduction_step_clarity — are the steps genuinely executable by a developer?
 """
+
+import json
+import os
+import re
+
+from langchain_anthropic import ChatAnthropic
 
 # ═══════════════════════════════════════════════════════════════════════════════
 # Person 1 evaluators — stages 1-3
@@ -447,3 +462,223 @@ def graceful_degradation(outputs: dict) -> dict:
         comment = "report produced but external sources had results — degradation not fully tested"
 
     return {"key": "graceful_degradation", "score": score, "comment": comment, "details": details}
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LLM-AS-JUDGE EVALUATORS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+_judge = ChatAnthropic(
+    model="claude-sonnet-4-6",
+    temperature=0,
+    max_tokens=512,
+    api_key=os.environ.get("ANTHROPIC_API_KEY"),
+)
+
+
+def _parse_judge_response(content: str) -> dict:
+    """Extract JSON score block from judge response.
+
+    Tries three strategies in order:
+      1. Direct parse (model returned bare JSON).
+      2. Extract from a fenced code block (```json ... ```).
+      3. Regex scan for the first {...} object in the text.
+    Falls back to score=0.5 only if all three fail.
+    """
+    text = content.strip()
+
+    # Strategy 1: bare JSON
+    try:
+        return json.loads(text)
+    except Exception:
+        pass
+
+    # Strategy 2: fenced code block
+    try:
+        fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+        if fence:
+            return json.loads(fence.group(1))
+    except Exception:
+        pass
+
+    # Strategy 3: first JSON object anywhere in the text
+    try:
+        obj = re.search(r"\{[^{}]*\}", text, re.DOTALL)
+        if obj:
+            return json.loads(obj.group(0))
+    except Exception:
+        pass
+
+    return {"score": 0.5, "reasoning": "Could not parse judge response"}
+
+
+async def root_cause_quality(inputs: dict, outputs: dict, reference_outputs: dict = None) -> dict:
+    """LLM judge: does the final report's root cause capture the real underlying cause?
+
+    When reference_outputs contains expected_root_cause_keywords, the judge checks
+    semantic alignment with those keywords. Without a reference it evaluates whether
+    the root cause is specific, mechanistic, and non-generic.
+    """
+    report = outputs.get("bug_report", {})
+    root_cause = report.get("root_cause", "")
+    if not root_cause:
+        return {"key": "root_cause_quality", "score": 0.0, "comment": "root_cause field missing"}
+
+    description = inputs.get("description", "")
+    keywords = (reference_outputs or {}).get("expected_root_cause_keywords", [])
+
+    if keywords:
+        reference_section = f"""
+Expected root cause keywords (from human review — any subset counts):
+{json.dumps(keywords, indent=2)}
+
+Score based on semantic alignment:
+- 1.0 = agent's root cause covers the same underlying mechanism as the keywords
+- 0.5 = partially correct — hits some keywords but misses key steps
+- 0.2 = describes symptoms rather than the mechanism
+- 0.0 = wrong component, wrong mechanism, or hallucinated
+"""
+    else:
+        reference_section = """
+No golden reference is available. Score based on quality alone:
+- 1.0 = specific, mechanistic, names exact code paths or invariants violated
+- 0.8 = mostly specific, minor vagueness
+- 0.4 = describes symptoms or general area without identifying the true cause
+- 0.0 = generic ("null pointer", "logic error") or contradicted by the description
+"""
+
+    prompt = f"""You are a QA engineering expert evaluating an AI-generated bug report.
+
+Bug description submitted by user:
+{description}
+
+Agent's root cause analysis:
+{root_cause}
+{reference_section}
+Return ONLY a JSON object: {{"score": <float 0.0-1.0>, "reasoning": "<1-2 sentences>"}}"""
+
+    response = await _judge.ainvoke([{"role": "user", "content": prompt}])
+    result = _parse_judge_response(response.content)
+    return {
+        "key": "root_cause_quality",
+        "score": result.get("score", 0.5),
+        "comment": result.get("reasoning", ""),
+    }
+
+
+async def report_coherence(inputs: dict, outputs: dict) -> dict:
+    """LLM judge: is the final bug report internally consistent, specific, and well-grounded?
+
+    No reference output needed — scores the logical quality of the report given the
+    original bug description. Penalises generic advice, contradictions, and off-topic
+    components.
+    """
+    report = outputs.get("bug_report", {})
+    if not report:
+        return {"key": "report_coherence", "score": 0.0, "comment": "bug_report missing"}
+
+    description = inputs.get("description", "")
+
+    report_summary = {
+        "title": report.get("title", ""),
+        "severity": report.get("severity", ""),
+        "root_cause": report.get("root_cause", ""),
+        "affected_components": [
+            c if isinstance(c, str) else c.get("component", str(c))
+            for c in report.get("affected_components", [])
+        ],
+        "recommendations": report.get("recommendations", []),
+        "confidence": report.get("confidence", ""),
+    }
+
+    prompt = f"""You are a QA engineering expert reviewing an AI-generated bug report for internal consistency and quality.
+
+Original bug description:
+{description}
+
+Generated bug report (key fields):
+{json.dumps(report_summary, indent=2, default=str)}
+
+Evaluate:
+1. Internal consistency — do severity, root cause, affected components, and recommendations all point to the same underlying problem?
+2. Specificity — does the report name real code-level things (files, classes, functions, invariants), or is it vague?
+3. Groundedness — are the recommendations actionable for this specific bug, not generic advice?
+4. Scope — are affected components actually relevant to the reported symptoms?
+
+Score 0.0 to 1.0:
+- 1.0 = fully coherent, specific, well-scoped
+- 0.7 = mostly coherent with minor inconsistencies or vague sections
+- 0.3 = some contradictions or significant vagueness
+- 0.0 = incoherent, contradictory, or entirely generic
+
+Return ONLY: {{"score": <float 0.0-1.0>, "reasoning": "<1-2 sentences>"}}"""
+
+    response = await _judge.ainvoke([{"role": "user", "content": prompt}])
+    result = _parse_judge_response(response.content)
+    return {
+        "key": "report_coherence",
+        "score": result.get("score", 0.5),
+        "comment": result.get("reasoning", ""),
+    }
+
+
+async def reproduction_step_clarity(inputs: dict, outputs: dict) -> dict:
+    """LLM judge: are the reproduction steps genuinely executable by a developer?
+
+    Deterministic checks count steps and verify field presence, but cannot tell
+    whether the actions make sense or are specific enough to follow. This judge
+    fills that gap.
+    """
+    report = outputs.get("bug_report", {})
+    if not report:
+        return {"key": "reproduction_step_clarity", "score": 0.0, "comment": "bug_report missing"}
+
+    steps = report.get("reproduction_steps", [])
+    if not steps:
+        return {"key": "reproduction_step_clarity", "score": 0.0, "comment": "reproduction_steps empty"}
+
+    description = inputs.get("description", "")
+    environment = inputs.get("environment", "unspecified")
+
+    steps_display = []
+    for s in steps:
+        if isinstance(s, dict):
+            steps_display.append({
+                "step": s.get("step", s.get("step_number", "?")),
+                "action": s.get("action", ""),
+                "expected": s.get("expected", s.get("expected_result", "")),
+            })
+        else:
+            steps_display.append(str(s))
+
+    prompt = f"""You are a QA engineer evaluating whether these reproduction steps are genuinely executable.
+
+Bug description:
+{description}
+
+Environment: {environment}
+
+Reproduction steps from the bug report:
+{json.dumps(steps_display, indent=2, default=str)}
+
+Evaluate:
+1. Clarity — could a developer unfamiliar with the codebase follow each step?
+2. Specificity — are actions concrete (specific menu names, settings, actions) or vague ("open the thing")?
+3. Correctness — do the steps plausibly lead to the described symptom?
+4. Completeness — are necessary prerequisites and expected outcomes stated?
+
+Score 0.0 to 1.0:
+- 1.0 = steps are clear, specific, correct, and immediately usable
+- 0.8 = mostly followable but some steps need clarification
+- 0.4 = steps are vague or partially incorrect — would require guesswork
+- 0.0 = steps cannot be followed, are wrong, or are missing entirely
+
+Return ONLY: {{"score": <float 0.0-1.0>, "reasoning": "<1-2 sentences>"}}"""
+
+    response = await _judge.ainvoke([{"role": "user", "content": prompt}])
+    result = _parse_judge_response(response.content)
+    return {
+        "key": "reproduction_step_clarity",
+        "score": result.get("score", 0.5),
+        "comment": result.get("reasoning", ""),
+    }

--- a/backend/evals/create_dataset.py
+++ b/backend/evals/create_dataset.py
@@ -298,7 +298,7 @@ GITHUB_ONLY_EXAMPLES = [
 # files, and components so evaluators can measure pipeline accuracy.
 
 BUG_EXAMPLES = [
-    # ── OpenTTD: UI crash — timetable widget layout assertion ─────────────────
+    # ── 1 ── OpenTTD: UI crash — timetable widget layout assertion ────────────
     {
         "_category": "UI crash — widget layout assertion",
         "inputs": {
@@ -334,6 +334,198 @@ BUG_EXAMPLES = [
             "expected_severity": "high",
             "expected_category": "crash",
             "min_reproduction_steps": 3,
+        },
+    },
+
+    # ── 2 ── osu! — Editor: collection mutation during enumeration ────────────
+    # Real issue: https://github.com/ppy/osu/issues/18527
+    {
+        "_category": "editor crash — collection mutation during enumeration",
+        "inputs": {
+            "description": (
+                "In the osu!(lazer) beatmap editor, opening the Timing screen "
+                "and attempting to add a new control point crashes the game to "
+                "desktop with an unhandled System.InvalidOperationException: "
+                "'Collection was modified; enumeration operation may not execute.' "
+                "The crash originates in TimingScreen.ControlPointList.addNew() "
+                "at TimingScreen.cs line 194 inside a List<T>.Enumerator.MoveNext() "
+                "call. Steps: (1) Open any beatmap in the editor. "
+                "(2) Navigate to the Timing screen. "
+                "(3) Select the first timing point in the list. "
+                "(4) Select any effect control point. "
+                "(5) Click the Add button. Game crashes immediately."
+            ),
+            "environment": "osu!lazer 5adbf85 (2022-06-02), Linux/Windows",
+            "severity_input": "medium",
+            "repo_name": "ppy/osu",
+        },
+        "outputs": {
+            "expected_root_cause_keywords": [
+                "addNew",
+                "List enumeration",
+                "collection modified",
+                "ControlPointList",
+                "TimingScreen",
+            ],
+            "expected_affected_files": [
+                "osu.Game/Screens/Edit/Timing/TimingScreen.cs",
+            ],
+            "expected_affected_components": [
+                "TimingScreen",
+                "ControlPointList",
+                "BeatmapEditor",
+            ],
+            "expected_severity": "medium",
+            "expected_category": "crash",
+            "min_reproduction_steps": 4,
+        },
+    },
+
+    # ── 3 ── OpenTTD — Vehicle cloning: pool assertion on stale order station ─
+    # Real issue: https://github.com/OpenTTD/OpenTTD/issues/10223
+    {
+        "_category": "data-integrity crash — pool assertion on deleted station order",
+        "inputs": {
+            "description": (
+                "Cloning any vehicle whose order list contains a reference to a "
+                "recently-deleted station crashes OpenTTD with an assertion in "
+                "pool_type.hpp: 'index < this->first_unused'. "
+                "The crash appears in the pool Get() accessor called from "
+                "vehicle_cmd.cpp after CloneVehicle returns INVALID_VEHICLE "
+                "without marking the result as failed, so the caller passes the "
+                "stale index back into the pool. "
+                "Steps: (1) Create a train and give it an order to stop at "
+                "Station A. (2) Delete Station A. (3) Open the train list and "
+                "click the Clone Vehicle button. (4) Click on the train to clone "
+                "it. Game crashes immediately with a popup loop — clicking OK "
+                "re-shows the same dialog and no crash log is written."
+            ),
+            "environment": "OpenTTD 13.0-beta2 / nightly 20221205, Windows/Linux",
+            "severity_input": "high",
+            "repo_name": "OpenTTD",
+        },
+        "outputs": {
+            "expected_root_cause_keywords": [
+                "CloneVehicle",
+                "INVALID_VEHICLE",
+                "total_cost",
+                "CMD_FAILED",
+                "pool_type",
+                "first_unused",
+            ],
+            "expected_affected_files": [
+                "src/vehicle_cmd.cpp",
+                "src/core/pool_type.hpp",
+            ],
+            "expected_affected_components": [
+                "Vehicle Cloning",
+                "Order Management",
+                "Command System",
+            ],
+            "expected_severity": "high",
+            "expected_category": "crash",
+            "min_reproduction_steps": 4,
+        },
+    },
+
+    # ── 4 ── Cataclysm-DDA — Chinese locale: multi-byte string in tile ID ─────
+    # Real issue: https://github.com/CleverRaven/Cataclysm-DDA/issues/78547
+    {
+        "_category": "encoding crash — multi-byte string in tile ID construction",
+        "inputs": {
+            "description": (
+                "On the macOS tiles build of Cataclysm-DDA, loading or entering "
+                "a map tile that contains graffiti written in Chinese (or any "
+                "multi-byte UTF-8 text) crashes the game with: "
+                "'Assertion failed: (sz != static_cast<size_t>(-1)), function "
+                "utf8_to_wstr, file catacharset.cpp, line 350.' "
+                "Root cause: cata_tiles.cpp constructs a tile ID from the "
+                "graffiti string by calling remove_punctuations() in output.cpp. "
+                "That function iterates the string byte-by-byte calling "
+                "std::ispunct() on each byte; for multi-byte UTF-8 sequences "
+                "this corrupts the string, and the downstream utf8_to_wstr() "
+                "call then fails the size assertion. "
+                "Steps: (1) Start a new game on macOS tiles build. "
+                "(2) Find or place a graffiti tile whose text contains Chinese "
+                "characters. (3) Move the character adjacent to the tile — game "
+                "crashes during map rendering."
+            ),
+            "environment": (
+                "Cataclysm-DDA experimental 2024-12-13, macOS 14 (Sonoma), tiles build"
+            ),
+            "severity_input": "high",
+            "repo_name": "CleverRaven/Cataclysm-DDA",
+        },
+        "outputs": {
+            "expected_root_cause_keywords": [
+                "remove_punctuations",
+                "ispunct",
+                "multi-byte",
+                "utf8_to_wstr",
+                "tile_id",
+                "cata_tiles",
+            ],
+            "expected_affected_files": [
+                "src/cata_tiles.cpp",
+                "src/output.cpp",
+                "src/catacharset.cpp",
+            ],
+            "expected_affected_components": [
+                "Tile Renderer",
+                "String / Charset Utilities",
+                "Graffiti Rendering",
+            ],
+            "expected_severity": "high",
+            "expected_category": "crash",
+            "min_reproduction_steps": 3,
+        },
+    },
+
+    # ── 5 ── Cataclysm-DDA — Faction manager: null deref on vehicle examine ───
+    # Real issue: https://github.com/CleverRaven/Cataclysm-DDA/issues/80567
+    {
+        "_category": "null-pointer crash — faction lookup when examining vehicle",
+        "inputs": {
+            "description": (
+                "Examining an APC (or other faction-owned vehicle) in "
+                "Cataclysm-DDA crashes the game with a segfault inside "
+                "faction_manager::get(const faction_id &id, const bool complain). "
+                "The crash trace shows the loop over faction_manager's internal "
+                "vector finds no matching faction_id and falls off the end, "
+                "returning a reference to a null/garbage faction object which is "
+                "then dereferenced by the vehicle inspection UI. "
+                "Steps: (1) Start or load a save that has military vehicles "
+                "spawned on the map. (2) Locate an APC or military truck. "
+                "(3) Move one step adjacent to the APC. "
+                "(4) Press 'e' (examine) on the APC tile. "
+                "Game crashes immediately with signal 11 / segfault."
+            ),
+            "environment": (
+                "Cataclysm-DDA experimental 2024-11-13 (76de484), Windows 10 22H2, tiles"
+            ),
+            "severity_input": "high",
+            "repo_name": "CleverRaven/Cataclysm-DDA",
+        },
+        "outputs": {
+            "expected_root_cause_keywords": [
+                "faction_manager::get",
+                "faction_id",
+                "null faction",
+                "vehicle examine",
+                "faction_no_faction",
+            ],
+            "expected_affected_files": [
+                "src/faction.cpp",
+                "src/vehicle.cpp",
+            ],
+            "expected_affected_components": [
+                "Faction Manager",
+                "Vehicle Examination",
+                "Map Interaction",
+            ],
+            "expected_severity": "high",
+            "expected_category": "crash",
+            "min_reproduction_steps": 4,
         },
     },
 ]

--- a/backend/evals/run_bug_evals.py
+++ b/backend/evals/run_bug_evals.py
@@ -1,0 +1,260 @@
+"""
+LangSmith evaluation runner for the Qlankr Sprint 3 bug reproduction pipeline.
+
+Usage:
+    cd backend && python -m evals.run_bug_evals [--dataset DATASET] [--concurrency N]
+
+Dataset:
+    qlankr-eval-bugs  (default) — bug examples with ground-truth root cause,
+                                  affected files, and expected components.
+    Run once to seed: python -m evals.create_dataset
+
+What this runs
+──────────────
+Deterministic evaluators (no LLM cost, always fast):
+  triage_accuracy, mechanics_grounding, reproduction_executability,
+  bug_pipeline_health, research_coverage, report_completeness,
+  report_actionability, evidence_quality, tool_efficiency, graceful_degradation
+
+LLM-as-judge evaluators (require ANTHROPIC_API_KEY, ~$0.01/example):
+  root_cause_quality       — semantic alignment with expected root-cause keywords
+  report_coherence         — internal consistency + specificity of the bug report
+  reproduction_step_clarity — are the repro steps actually executable?
+
+Improving the judges
+────────────────────
+All three judge prompts live at the bottom of evals/bug_evaluators.py.
+To adjust scoring:
+  - Edit the rubric anchors (1.0 / 0.7 / 0.4 / 0.0 bullet points) in each prompt.
+  - Add more golden examples to BUG_EXAMPLES in evals/create_dataset.py, then
+    re-run `python -m evals.create_dataset` to push them to LangSmith.
+  - Compare experiment runs side-by-side in the LangSmith UI.
+"""
+
+import argparse
+import asyncio
+import os
+import sys
+from typing import Any
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(os.path.dirname(__file__), "../../.env"))
+
+from langsmith import Client
+from langsmith.evaluation import aevaluate
+
+# ── Deterministic evaluators ──────────────────────────────────────────────────
+from evals.bug_evaluators import (
+    # Stage 1-3
+    triage_accuracy,
+    mechanics_grounding,
+    reproduction_executability,
+    # Stage 4-5 + pipeline
+    bug_pipeline_health,
+    research_coverage,
+    report_completeness,
+    report_actionability,
+    evidence_quality,
+    tool_efficiency,
+    graceful_degradation,
+    # LLM judges
+    root_cause_quality,
+    report_coherence,
+    reproduction_step_clarity,
+)
+
+_DETERMINISTIC_EVALUATORS = [
+    triage_accuracy,
+    mechanics_grounding,
+    reproduction_executability,
+    bug_pipeline_health,
+    research_coverage,
+    report_completeness,
+    report_actionability,
+    evidence_quality,
+    tool_efficiency,
+    graceful_degradation,
+]
+
+_JUDGE_EVALUATORS = [
+    root_cause_quality,
+    report_coherence,
+    reproduction_step_clarity,
+]
+
+_ALL_EVALUATORS = _DETERMINISTIC_EVALUATORS + _JUDGE_EVALUATORS
+
+_DEFAULT_DATASET = "qlankr-eval-bugs"
+
+
+# ── Target: drive the full bug pipeline, auto-approve checkpoints ─────────────
+
+async def bug_target(inputs: dict) -> dict:
+    """
+    LangSmith target function for the bug reproduction pipeline.
+
+    Drives run_bug_agent() through all checkpoints (auto-approving each one)
+    and returns a full_state dict suitable for all evaluators.
+
+    full_state keys used by evaluators:
+      triage, mechanics, reproduction_plan, research_findings,
+      bug_report, tool_calls_used
+    """
+    from agent.bug_agent import run_bug_agent, continue_bug_agent, BugResultEvent
+    from models import CheckpointEvent, ErrorEvent
+
+    description = inputs.get("description", "")
+    environment = inputs.get("environment", "unspecified")
+    severity_input = inputs.get("severity_input", "medium")
+    repo_name = inputs.get("repo_name")
+    session_id = f"eval-{id(inputs)}"
+
+    result_event = None
+    error_msg = None
+    checkpoint_count = 0
+    max_checkpoints = 5
+
+    async def _drain(generator):
+        """Consume the event stream; return the first terminal event (result/checkpoint/error)."""
+        async for event in generator:
+            if isinstance(event, (CheckpointEvent, BugResultEvent, ErrorEvent)):
+                return event
+        return None
+
+    # Start the pipeline
+    terminal = await _drain(run_bug_agent(
+        description=description,
+        environment=environment,
+        severity_input=severity_input,
+        repo_name=repo_name,
+        session_id=session_id,
+    ))
+
+    # Auto-approve every checkpoint until we get a BugResultEvent
+    while isinstance(terminal, CheckpointEvent) and checkpoint_count < max_checkpoints:
+        checkpoint_count += 1
+        terminal = await _drain(continue_bug_agent(
+            session_id=terminal.session_id,
+            user_response={"action": "approve"},
+        ))
+
+    if isinstance(terminal, ErrorEvent):
+        error_msg = terminal.message
+    elif isinstance(terminal, BugResultEvent):
+        result_event = terminal
+
+    if result_event is not None:
+        # full_state has all stage outputs — preferred path
+        if result_event.full_state:
+            return result_event.full_state
+        # Fallback: build minimal dict from the result event fields
+        br = result_event.bug_report
+        if hasattr(br, "model_dump"):
+            br = br.model_dump()
+        elif not isinstance(br, dict):
+            br = {}
+        return {"bug_report": br}
+
+    # Pipeline failed — return error signal so evaluators score 0
+    return {"error": error_msg or f"no result after {checkpoint_count} checkpoints"}
+
+
+# ── Runner ────────────────────────────────────────────────────────────────────
+
+async def run_eval(
+    dataset_name: str = _DEFAULT_DATASET,
+    judges_enabled: bool = True,
+    max_concurrency: int = 1,
+) -> None:
+    evaluators = _ALL_EVALUATORS if judges_enabled else _DETERMINISTIC_EVALUATORS
+    label = "full (deterministic + judges)" if judges_enabled else "deterministic only"
+    experiment_prefix = "bug-repro-full" if judges_enabled else "bug-repro-det"
+
+    print(f"\n{'='*60}")
+    print(f"Bug reproduction eval — {label}")
+    print(f"Dataset:     {dataset_name}")
+    print(f"Evaluators:  {len(evaluators)} ({len(_DETERMINISTIC_EVALUATORS)} det + "
+          f"{len(_JUDGE_EVALUATORS) if judges_enabled else 0} judges)")
+    print(f"Concurrency: {max_concurrency}")
+    print(f"{'='*60}")
+
+    results = await aevaluate(
+        bug_target,
+        data=dataset_name,
+        evaluators=evaluators,
+        experiment_prefix=experiment_prefix,
+        max_concurrency=max_concurrency,
+        metadata={
+            "pipeline": "bug_reproduction",
+            "judges_enabled": judges_enabled,
+        },
+    )
+
+    # Print summary table
+    score_map: dict[str, list[float]] = {}
+    async for result in results:
+        for eval_result in result.get("evaluation_results", {}).get("results", []):
+            key = eval_result.key
+            score = eval_result.score
+            if score is not None:
+                score_map.setdefault(key, []).append(score)
+
+    if score_map:
+        print(f"\n{'Metric':<35} {'Mean':>6}  {'Min':>6}  {'Max':>6}")
+        print("-" * 57)
+        det_keys = {f.__name__ for f in _DETERMINISTIC_EVALUATORS}
+        for metric, scores in sorted(score_map.items()):
+            mean = sum(scores) / len(scores)
+            tag = "     " if metric in det_keys else " [J] "  # [J] = LLM judge
+            print(f"  {metric:<33}{tag}{mean:>6.2f}  {min(scores):>6.2f}  {max(scores):>6.2f}")
+        print("\n  [J] = LLM-as-judge metric")
+    else:
+        print("  (no scores returned — check LangSmith UI)")
+
+    print("\nDone. View full results at https://smith.langchain.com")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Run Qlankr bug reproduction evals",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--dataset",
+        default=_DEFAULT_DATASET,
+        help=f"LangSmith dataset name (default: {_DEFAULT_DATASET})",
+    )
+    parser.add_argument(
+        "--no-judges",
+        action="store_true",
+        help="Skip LLM-as-judge evaluators (free, fast, deterministic only)",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=1,
+        help="Max parallel pipeline runs (default: 1 — bug pipeline is expensive)",
+    )
+    args = parser.parse_args()
+
+    # Verify the dataset exists
+    client = Client()
+    existing = {ds.name for ds in client.list_datasets()}
+    if args.dataset not in existing:
+        print(f"ERROR: Dataset '{args.dataset}' not found in LangSmith.")
+        print("Run first:  cd backend && python -m evals.create_dataset")
+        sys.exit(1)
+
+    asyncio.run(run_eval(
+        dataset_name=args.dataset,
+        judges_enabled=not args.no_judges,
+        max_concurrency=args.concurrency,
+    ))
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/evals/run_evals.py
+++ b/backend/evals/run_evals.py
@@ -1,21 +1,25 @@
 """
-Main evaluation runner for the Qlankr Sprint 2 agent.
+Main evaluation runner for the Qlankr agent (PR analysis + bug reproduction).
 
 Usage:
     cd backend && python -m evals.run_evals [--suite SUITE] [--dataset DATASET]
 
 Suites:
-    integration — full pipeline, integration path
-    e2e         — full pipeline, e2e path
-    all         — both suites (default)
+    integration — PR impact analysis, integration test path
+    e2e         — PR impact analysis, E2E test path
+    bug         — bug reproduction pipeline (deterministic + LLM judges)
+    all         — all three suites (default)
 
-Datasets:
+Datasets (PR analysis):
     indexed     — qlankr-eval-indexed (Qlankr repo, full pipeline with GitNexus)
     github      — qlankr-eval-github  (external repos, GitHub-only)
-    all         — both datasets (default)
+
+Dataset (bug):
+    qlankr-eval-bugs  (fixed, seeded by evals/create_dataset.py)
 
 Examples:
-    python -m evals.run_evals                        # run everything
+    python -m evals.run_evals                              # run everything
+    python -m evals.run_evals --suite bug                  # bug repro only
     python -m evals.run_evals --suite integration --dataset indexed
     python -m evals.run_evals --suite e2e --dataset github
 """
@@ -60,6 +64,7 @@ from evals.target import (
     agent_target_integration,
     agent_target_e2e,
 )
+from evals.run_bug_evals import run_eval as _run_bug_eval
 
 # ── Evaluator sets per suite ──────────────────────────────────────────────────
 
@@ -189,7 +194,7 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Run Qlankr agent evals")
     parser.add_argument(
         "--suite",
-        choices=["integration", "e2e", "all"],
+        choices=["integration", "e2e", "bug", "all"],
         default="all",
         help="Which eval suite to run (default: all)",
     )
@@ -197,33 +202,58 @@ def main() -> None:
         "--dataset",
         choices=["indexed", "github", "all"],
         default="all",
-        help="Which dataset to evaluate on (default: all)",
+        help="PR-analysis dataset (default: all). Ignored when --suite bug.",
     )
     parser.add_argument(
         "--concurrency",
         type=int,
         default=2,
-        help="Max parallel eval runs (default: 2)",
+        help="Max parallel eval runs (default: 2). Bug suite defaults to 1.",
+    )
+    parser.add_argument(
+        "--no-judges",
+        action="store_true",
+        help="Skip LLM-as-judge evaluators in the bug suite (faster, no API cost).",
     )
     args = parser.parse_args()
 
-    suites = list(SUITES.keys()) if args.suite == "all" else [args.suite]
-    datasets = list(DATASETS.keys()) if args.dataset == "all" else [args.dataset]
-
-    # Verify datasets exist in LangSmith
     client = Client()
     existing = {ds.name for ds in client.list_datasets()}
-    missing = [DATASETS[d] for d in datasets if DATASETS[d] not in existing]
-    if missing:
-        print(f"ERROR: These datasets don't exist in LangSmith: {missing}")
-        print("Run first:  cd backend && python -m evals.create_dataset")
-        sys.exit(1)
 
-    print(f"Running suites: {suites}")
-    print(f"On datasets:    {datasets}")
-    print(f"Concurrency:    {args.concurrency}")
+    run_pr_suites = args.suite in ("integration", "e2e", "all")
+    run_bug_suite = args.suite in ("bug", "all")
 
-    asyncio.run(run_all(suites, datasets, args.concurrency))
+    # ── PR analysis suites ────────────────────────────────────────────────────
+    if run_pr_suites:
+        pr_suite_names = [s for s in SUITES if args.suite == "all" or s == args.suite]
+        datasets = list(DATASETS.keys()) if args.dataset == "all" else [args.dataset]
+
+        missing = [DATASETS[d] for d in datasets if DATASETS[d] not in existing]
+        if missing:
+            print(f"ERROR: These datasets don't exist in LangSmith: {missing}")
+            print("Run first:  cd backend && python -m evals.create_dataset")
+            sys.exit(1)
+
+        print(f"Running PR suites: {pr_suite_names}")
+        print(f"On datasets:       {datasets}")
+        asyncio.run(run_all(pr_suite_names, datasets, args.concurrency))
+
+    # ── Bug reproduction suite ────────────────────────────────────────────────
+    if run_bug_suite:
+        bug_dataset = "qlankr-eval-bugs"
+        if bug_dataset not in existing:
+            print(f"ERROR: Dataset '{bug_dataset}' not found in LangSmith.")
+            print("Run first:  cd backend && python -m evals.create_dataset")
+            sys.exit(1)
+
+        # Bug pipeline is expensive — use concurrency=1 unless user explicitly raised it
+        bug_concurrency = 1 if args.concurrency == 2 else args.concurrency
+        asyncio.run(_run_bug_eval(
+            dataset_name=bug_dataset,
+            judges_enabled=not args.no_judges,
+            max_concurrency=bug_concurrency,
+        ))
+
     print("\nDone. View results at https://smith.langchain.com")
 
 

--- a/backend/tests/agent/test_bug_reproduction.py
+++ b/backend/tests/agent/test_bug_reproduction.py
@@ -39,6 +39,8 @@ from evals.bug_evaluators import (
     triage_accuracy, mechanics_grounding, reproduction_executability,
     bug_pipeline_health, research_coverage, report_completeness,
     report_actionability, evidence_quality, tool_efficiency, graceful_degradation,
+    # LLM-as-judge (async)
+    root_cause_quality, report_coherence, reproduction_step_clarity,
 )
 
 # ── Sample bug description ────────────────────────────────────────────────────
@@ -102,7 +104,7 @@ def _print_result(stage: str, result: dict) -> None:
 
 def _print_evals(combined: dict) -> None:
     print(f"\n{'='*60}")
-    print("=== EVALUATOR SCORES ===")
+    print("=== EVALUATOR SCORES (deterministic) ===")
     print(f"{'='*60}")
     all_evals = [
         triage_accuracy, mechanics_grounding, reproduction_executability,
@@ -118,6 +120,23 @@ def _print_evals(combined: dict) -> None:
         for d in result.get("details", []):
             icon = "✓" if d["passed"] else "✗"
             print(f"    {icon} {d['check']:<50} {d['value']}")
+
+
+async def _print_judge_evals(combined: dict, inputs: dict) -> None:
+    """Run the three async LLM-as-judge evaluators and print their scores."""
+    print(f"\n{'='*60}")
+    print("=== EVALUATOR SCORES (LLM-as-judge) ===")
+    print(f"{'='*60}")
+    judges = [root_cause_quality, report_coherence, reproduction_step_clarity]
+    for judge in judges:
+        try:
+            result = await judge(inputs=inputs, outputs=combined)
+            score_bar = "█" * int(result["score"] * 10) + "░" * (10 - int(result["score"] * 10))
+            print(f"\n  {result['key']}  [J]")
+            print(f"  score   : {score_bar}  {result['score']:.2f}")
+            print(f"  summary : {result.get('comment', '')}")
+        except Exception as exc:
+            print(f"\n  {judge.__name__}  [J]  ERROR: {exc}")
 
 
 # ── Full pipeline via bug_agent (recommended) ─────────────────────────────────
@@ -181,6 +200,12 @@ async def run_pipeline():
         return
 
     _print_evals(combined)
+
+    inputs = {
+        "description": BUG_DESCRIPTION,
+        "environment": _fixture.get("environment", "unspecified"),
+    }
+    await _print_judge_evals(combined, inputs)
 
 
 # ── Individual stage runners (bypass graph, useful for quick iteration) ───────


### PR DESCRIPTION
Add LLM-as-judge evaluation for bug reproduction
What was missing: The bug pipeline had only deterministic evaluators (field presence, step counts, budget checks). Nothing could tell whether the root cause was actually correct or whether the reproduction steps were followable.

What was added: 3 LLM-as-judge evaluators in bug_evaluators.py:

- root_cause_quality — does the root cause match the expected mechanism?
- report_coherence — is the report specific, consistent, and non-generic?
- reproduction_step_clarity — could a developer actually follow these steps?
- run_bug_evals.py (new) — LangSmith runner for the bug suite, mirrors how run_evals.py works for PR analysis. --no-judges flag for fast free runs.
- run_evals.py — added --suite bug so both pipelines run from one entry point.
- create_dataset.py — expanded golden dataset from 1 to 5 bug examples across 3 real open-source games, covering 5 distinct bug classes (widget assertion, collection mutation, pool corruption, encoding, null deref).
- test_bug_reproduction.py — local test harness now prints all 13 scores (10 deterministic + 3 judges) without needing LangSmith.